### PR TITLE
Fix ARM64 image smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,20 @@ jobs:
 
   image:
     name: Image smoke (${{ matrix.platform }})
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
             suffix: amd64
+            runner: ubuntu-24.04
           - platform: linux/arm64
             suffix: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

- run each image smoke job on a native GitHub-hosted runner for its architecture
- remove QEMU from the image smoke matrix
- cap each image job at 30 minutes so a stalled browser smoke test cannot occupy a runner for six hours

## Root cause

The ARM64 image built successfully, but the Chromium `--dump-dom` smoke check hung while running through QEMU on the AMD64 runner. GitHub eventually cancelled the job at its six-hour limit. The same smoke check already succeeds natively on AMD64.

## Validation

- `make verify`
- `git diff --check`
- `actionlint` (Docker image)
