### PR TITLE
fix(browser-desktop): remove redundant floating open-browser button

### DIFF
--- a/plugins/dsh-browser-desktop/client.js
+++ b/plugins/dsh-browser-desktop/client.js
@@ -11,8 +11,6 @@ window.__ModuleLoader__.load({
       browserFrame: zh ? '容器 Chromium 桌面' : 'Container Chromium desktop',
       close: zh ? '关闭' : 'Close',
       maximize: zh ? '最大化' : 'Maximize',
-      open: zh ? '打开浏览器' : 'Open browser',
-      openHere: zh ? '在当前页面打开容器浏览器' : 'Open the container browser here',
       openNew: zh ? '新窗口打开' : 'Open in new window',
       openTitle: zh ? '打开容器浏览器' : 'Open container browser',
       resize: zh ? '调整浏览器窗口大小' : 'Resize browser window',
@@ -286,39 +284,7 @@ window.__ModuleLoader__.load({
         setMaximized(true)
       }
 
-      if (!visible) {
-        return React.createElement(
-          'button',
-          {
-            type: 'button',
-            title: messages.openHere,
-            'aria-label': messages.openHere,
-            onClick: () => setOpened(true),
-            style: {
-              position: 'absolute',
-              top: '14px',
-              right: '16px',
-              zIndex: 90,
-              pointerEvents: 'auto',
-              height: '38px',
-              padding: '0 14px',
-              border: '1px solid var(--dsw-alias-border-l2)',
-              borderRadius: '19px',
-              background: 'var(--dsw-alias-bg-base)',
-              color: 'var(--dsw-alias-label-primary)',
-              boxShadow: '0 4px 18px rgba(0,0,0,.14)',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '7px',
-              fontSize: '14px',
-              fontWeight: 500
-            }
-          },
-          React.createElement('span', { style: { fontSize: '17px', lineHeight: 1 } }, '🌐'),
-          React.createElement('span', null, messages.open)
-        )
-      }
+      if (!visible) return null
 
       return React.createElement(
         'section',


### PR DESCRIPTION
## Summary

Removes the redundant floating **Open browser** button that the dsh-browser-desktop client rendered on top of the page whenever the browser panel was closed.

The plugin already registers a sidebar entry point via sidebar.footer.action (the 🌐 Browser button), so the additional absolutely-positioned pill in shell.overlay (`top: 14px; right: 16px; z-index: 90`) is a duplicate that:

- overlaps and is obscured by other top-of-screen UI (e.g. a session tab bar at `z-index: 1000`) mounted in the same shell.overlay area — only the lower half of the pill stays clickable;
- has no z-index or coordinate coordination with other overlay widgets in the same viewport corner.

## Change

`plugins/dsh-browser-desktop/client.js`:

- When the browser is closed, the overlay now renders `null` instead of the floating pill.
- The sidebar rowser button remains the single, always-visible entry point and still opens the panel.

## Why not just move the button?

Only adjusting z-index cannot fix this — both widgets occupy the same top-right geometry, so whichever has the higher stacking context wins and the other becomes unclickable. If a visible in-page entry point is ever wanted again, it should be positioned **relative to its own container** (e.g. the sidebar footer), never absolutely against the viewport corner, so it cannot collide with other overlay widgets.

## Notes

- No behavioral change to the browser panel itself (drag, resize, maximize, open-in-new-window, close).
- Verified: with this branch, no floating button is rendered when the browser is closed; opening from the sidebar still works.