### PR TITLE
feat: upgrade DSH to 0.1.1-rc.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           tags: deepseek-harness:ci-${{ matrix.suffix }}
           cache-from: type=gha,scope=${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}
-      - run: ./scripts/smoke.sh deepseek-harness:ci-${{ matrix.suffix }} 0.1.0-rc.6
+      - run: ./scripts/smoke.sh deepseek-harness:ci-${{ matrix.suffix }} 0.1.1-rc.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented here.
 
+## 0.1.1 - 2026-08-24
+
+- Upgrade the official runtime to `@deepseek-ai/dsh@0.1.1-rc.2`.
+- Disable the upstream automatic browser handoff so the container-managed Chromium desktop remains the single browser lifecycle owner.
+- Declare browser desktop plugin compatibility with both the original `0.1.0-rc.6` baseline and the new `0.1.1-rc.2` release candidate.
+- Keep the Node.js 24 base, pnpm runtime, hardened Compose deployment, and dual-architecture image layout unchanged after native ARM64 validation.
+
 ## 0.1.0 - 2026-08-13
 
 - Package the official `@deepseek-ai/dsh@0.1.0-rc.6` npm distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG NODE_IMAGE=node:24-bookworm-slim
 FROM ${NODE_IMAGE} AS installer
 
-ARG DSH_VERSION=0.1.0-rc.6
+ARG DSH_VERSION=0.1.1-rc.2
 ARG PNPM_VERSION=10.15.1
 
 # node-pty publishes prebuilds for only some Linux architectures. Keep a
@@ -25,7 +25,7 @@ RUN apt-get update \
 
 FROM ${NODE_IMAGE}
 
-ARG DSH_VERSION=0.1.0-rc.6
+ARG DSH_VERSION=0.1.1-rc.2
 ARG PNPM_VERSION=10.15.1
 
 LABEL org.opencontainers.image.title="DeepSeek Harness Docker (Community)" \
@@ -229,4 +229,4 @@ EXPOSE 3080 6080
 # internal-module access flag to the dsh process instead of exporting it via
 # NODE_OPTIONS to every child process the agent starts.
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/deepseek-harness-entrypoint"]
-CMD ["web", "--patch", "/opt/deepseek-harness/web.cordis.patch.yml"]
+CMD ["web", "--patch", "/opt/deepseek-harness/web.cordis.patch.yml", "--no-open"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 IMAGE ?= runzhliu/deepseek-harness
-VERSION ?= 0.1.0-rc.6
+VERSION ?= 0.1.1-rc.2
 PLATFORMS ?= linux/amd64,linux/arm64
 
-.PHONY: help build multiarch-build pull up down logs compose-check helm-check plugin-check verify smoke inspect
+.PHONY: help build multiarch-build push pull up down logs compose-check helm-check plugin-check verify smoke inspect
 
 help:
 	@echo "build            Build the local platform image"
 	@echo "multiarch-build  Build both release platforms without pushing"
+	@echo "push             Build and push the versioned multi-platform image"
 	@echo "pull             Pull the published image"
 	@echo "up/down/logs     Manage the Compose service"
 	@echo "verify           Validate Compose and Helm rendering"
@@ -19,6 +20,9 @@ build:
 
 multiarch-build:
 	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(VERSION) --tag $(IMAGE):$(VERSION) .
+
+push:
+	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(VERSION) --tag $(IMAGE):$(VERSION) --push .
 
 pull:
 	docker pull $(IMAGE):$(VERSION)

--- a/README.en.md
+++ b/README.en.md
@@ -2,16 +2,16 @@
 
 English | [简体中文](README.md)
 
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek_Harness-0.1.0--rc.6-4f46e5)](https://www.npmjs.com/package/@deepseek-ai/dsh)
+[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek_Harness-0.1.1--rc.2-4f46e5)](https://www.npmjs.com/package/@deepseek-ai/dsh)
 [![Docker Image](https://img.shields.io/badge/docker.io-runzhliu%2Fdeepseek--harness-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/runzhliu/deepseek-harness)
 [![Node.js](https://img.shields.io/badge/Node.js-24-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A production-minded community container project for the official DeepSeek Harness `@deepseek-ai/dsh` package. It provides a multi-stage Dockerfile, a hardened Compose setup, and a single-replica StatefulSet Helm chart without forking or rebuilding the upstream monorepo.
 
-> Current baseline: `@deepseek-ai/dsh@0.1.0-rc.6`. DeepSeek Harness is still a release candidate. Re-run the build and smoke tests before every version upgrade.
+> Current baseline: `@deepseek-ai/dsh@0.1.1-rc.2`. DeepSeek Harness is still a release candidate. Re-run the build and smoke tests before every version upgrade.
 
-`0.1.0-rc.6` maps directly to the latest official `@deepseek-ai/dsh` artifact in the npm Registry at build time; it is not a project-defined version. The public upstream `master` still identified itself as `rc.5` at that point. This project packages the installable npm distribution instead of building source, and intentionally does not publish a drifting Docker `latest` tag.
+`0.1.1-rc.2` maps directly to the official `@deepseek-ai/dsh` artifact in the npm Registry and its matching GitHub Release; it is not a project-defined version. This project packages the installable npm distribution instead of building source, and intentionally does not publish a drifting Docker `latest` tag.
 
 📖 Further reading: [DeepSeek Harness GitHub repository deep dive](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-repository-analysis/) · [Docker, Compose, and Helm deployment guide](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-runtime-containerization/) (Chinese)
 
@@ -120,7 +120,7 @@ docker compose ps
 
 Open <http://127.0.0.1:3080> and configure a model and credentials in Settings. The **Browser** action in the sidebar opens an interactive container Chromium directly inside the Harness Web UI. The named `dsh-home` volume preserves both Harness state and the browser profile across container recreation.
 
-The default image is [`runzhliu/deepseek-harness:0.1.0-rc.6`](https://hub.docker.com/r/runzhliu/deepseek-harness). Compose retains the `build` definition so the image remains reproducible and reviewable; run `docker compose build --pull` before startup when you explicitly want a local build.
+The default image is [`runzhliu/deepseek-harness:0.1.1-rc.2`](https://hub.docker.com/r/runzhliu/deepseek-harness). Compose retains the `build` definition so the image remains reproducible and reviewable; run `docker compose build --pull` before startup when you explicitly want a local build.
 
 ### Browser inside the Web UI
 
@@ -146,7 +146,7 @@ The plugin is a standalone DSH bundle under [`plugins/dsh-browser-desktop`](plug
 
 ```bash
 npm pack ./plugins/dsh-browser-desktop --pack-destination /tmp
-dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.0.tgz
+dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.1.tgz
 ```
 
 After npm publication, install it with `dsh plugin --profile web add @runzhliu/dsh-browser-desktop`. The npm package supplies only the Harness host/Web integration; it does not install Chromium, Xvfb, or noVNC. This repository's image is the complete reference runtime. DeepSeek Harness currently discovers community plugins through npm/GitHub and the `dsh-plugin` GitHub topic rather than a curated marketplace submission queue.
@@ -167,7 +167,7 @@ docker compose down
 Build:
 
 ```bash
-docker build -t runzhliu/deepseek-harness:0.1.0-rc.6 .
+docker build -t runzhliu/deepseek-harness:0.1.1-rc.2 .
 ```
 
 Run the Web UI:
@@ -181,7 +181,7 @@ docker run --rm \
   --shm-size 1g \
   --mount type=volume,src=dsh-home,dst=/home/node/.dsh \
   --mount type=bind,src="$PWD",dst=/workspace \
-  runzhliu/deepseek-harness:0.1.0-rc.6
+  runzhliu/deepseek-harness:0.1.1-rc.2
 ```
 
 Do not shorten the publication to `-p 3080:3080`, and do not place this service behind a public Ingress.
@@ -195,7 +195,7 @@ docker run --rm \
   --env DEEPSEEK_API_KEY \
   --mount type=volume,src=dsh-home,dst=/home/node/.dsh \
   --mount type=bind,src="$PWD",dst=/workspace \
-  runzhliu/deepseek-harness:0.1.0-rc.6 \
+  runzhliu/deepseek-harness:0.1.1-rc.2 \
   --profile headless "summarize this repository"
 ```
 
@@ -212,7 +212,7 @@ helm upgrade --install deepseek-harness charts/deepseek-harness \
   --namespace deepseek-harness \
   --create-namespace \
   --set image.repository=runzhliu/deepseek-harness \
-  --set image.tag=0.1.0-rc.6
+  --set image.tag=0.1.1-rc.2
 ```
 
 Kind or Minikube can pull the default `runzhliu/deepseek-harness` image directly, or you can load a local image under the same name first.
@@ -246,15 +246,17 @@ The build argument pins the package:
 
 ```bash
 docker build \
-  --build-arg DSH_VERSION=0.1.0-rc.6 \
-  -t runzhliu/deepseek-harness:0.1.0-rc.6 .
+  --build-arg DSH_VERSION=0.1.1-rc.2 \
+  -t runzhliu/deepseek-harness:0.1.1-rc.2 .
 ```
 
 Compose uses the same variable:
 
 ```bash
-DSH_VERSION=0.1.0-rc.6 docker compose build --pull
+DSH_VERSION=0.1.1-rc.2 docker compose build --pull
 ```
+
+Maintainers can run `make push` to build and publish the `linux/amd64` and `linux/arm64` manifests under the same versioned tag. The target does not create a `latest` tag.
 
 Do not install an unbounded `latest` tag. Release-candidate behavior changes quickly, and exact versions make bugs reproducible.
 
@@ -274,9 +276,9 @@ See [SECURITY.md](SECURITY.md) before changing any network or privilege setting.
 Run at least these checks for every DSH upgrade:
 
 ```bash
-docker run --rm runzhliu/deepseek-harness:0.1.0-rc.6 --version
+docker run --rm runzhliu/deepseek-harness:0.1.1-rc.2 --version
 
-docker run --rm --entrypoint dsh runzhliu/deepseek-harness:0.1.0-rc.6 \
+docker run --rm --entrypoint dsh runzhliu/deepseek-harness:0.1.1-rc.2 \
   web --patch /opt/deepseek-harness/web.cordis.patch.yml --dump-config
 
 docker compose up -d
@@ -288,7 +290,7 @@ helm lint --strict charts/deepseek-harness
 helm template deepseek-harness charts/deepseek-harness >/dev/null
 ```
 
-Acceptance criteria: the CLI reports the pinned version; the dumped `webserver.config.host` is `0.0.0.0`; the home page returns 2xx; Compose reaches `healthy`; logs contain no plugin/config errors; and Helm renders both persistent and ephemeral-storage variants. Build both `linux/amd64` and `linux/arm64` and actually spawn a PTY before publishing because terminal and sandbox dependencies include native code. The common entry points are `make verify`, `make build`, and `make smoke`.
+Acceptance criteria: the CLI reports the pinned version; the dumped `webserver.config.host` is `0.0.0.0`; the home page returns 2xx; Compose reaches `healthy`; logs contain no plugin/config errors; the container does not try to hand off to a host browser; and Helm renders both persistent and ephemeral-storage variants. Build both `linux/amd64` and `linux/arm64` and actually spawn a PTY before publishing because terminal and sandbox dependencies include native code. The common entry points are `make verify`, `make build`, and `make smoke`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 [English](README.en.md) | 简体中文
 
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek_Harness-0.1.0--rc.6-4f46e5)](https://www.npmjs.com/package/@deepseek-ai/dsh)
+[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek_Harness-0.1.1--rc.2-4f46e5)](https://www.npmjs.com/package/@deepseek-ai/dsh)
 [![Docker Image](https://img.shields.io/badge/docker.io-runzhliu%2Fdeepseek--harness-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/runzhliu/deepseek-harness)
 [![Node.js](https://img.shields.io/badge/Node.js-24-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 这是一个可直接构建的 DeepSeek Harness 社区容器方案，默认运行官方 `@deepseek-ai/dsh` 的 Web UI。它不构建或修改 DeepSeek Harness 源码，只把官方 npm 发行物装入一个精简、非 root 的 Node.js 24 运行时。
 
-> 当前基线：`@deepseek-ai/dsh@0.1.0-rc.6`。DeepSeek Harness 仍处于 RC 阶段；升级前应重新完成本文的构建和 Smoke Test。
+> 当前基线：`@deepseek-ai/dsh@0.1.1-rc.2`。DeepSeek Harness 仍处于 RC 阶段；升级前应重新完成本文的构建和 Smoke Test。
 
-`0.1.0-rc.6` 直接对应构建时官方 npm Registry 的 `@deepseek-ai/dsh` 最新发行物，并非本项目自定义版本。上游公开 `master` 当时仍标记 `rc.5`；本项目封装 npm 成品而不从源码构建，因此以可安装的官方发行物为基线，并故意不发布漂移的 Docker `latest` 标签。
+`0.1.1-rc.2` 直接对应官方 npm Registry 与 GitHub Release 的 `@deepseek-ai/dsh` 发行物，并非本项目自定义版本。本项目封装 npm 成品而不从源码构建，因此以可安装的官方发行物为基线，并故意不发布漂移的 Docker `latest` 标签。
 
 📖 延伸阅读：[DeepSeek Harness GitHub 仓库深度解析](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-repository-analysis/) · [Docker、Compose 与 Helm 部署实战](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-runtime-containerization/)
 
@@ -119,7 +119,7 @@ docker compose ps
 
 浏览器打开 <http://127.0.0.1:3080>，在设置页配置模型和凭据。侧边栏的“浏览器”按钮会在 Harness WebUI 内直接打开可交互的容器 Chromium；配置和浏览器 Profile 写入命名卷 `dsh-home`，重建容器后仍会保留。
 
-默认镜像为 Docker Hub 上的 [`runzhliu/deepseek-harness:0.1.0-rc.6`](https://hub.docker.com/r/runzhliu/deepseek-harness)。Compose 同时保留 `build` 配置，方便审查并从本目录复现镜像；如需本地构建，执行 `docker compose build --pull` 后再启动。
+默认镜像为 Docker Hub 上的 [`runzhliu/deepseek-harness:0.1.1-rc.2`](https://hub.docker.com/r/runzhliu/deepseek-harness)。Compose 同时保留 `build` 配置，方便审查并从本目录复现镜像；如需本地构建，执行 `docker compose build --pull` 后再启动。
 
 ### WebUI 内置浏览器
 
@@ -145,7 +145,7 @@ Compose 为 Chromium 配置了 1GB `/dev/shm`。启动器只对浏览器进程�
 
 ```bash
 npm pack ./plugins/dsh-browser-desktop --pack-destination /tmp
-dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.0.tgz
+dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.1.tgz
 ```
 
 发布到 npm 后可直接执行 `dsh plugin --profile web add @runzhliu/dsh-browser-desktop`。该 npm 包只负责 Harness Host/WebUI 集成，不会自行安装 Chromium、Xvfb 或 noVNC；本仓库 Docker 镜像是完整的参考运行时。DeepSeek Harness 当前通过 npm/GitHub 和 `dsh-plugin` GitHub topic 发现社区插件，并没有单独的审核型插件市场提交流程。
@@ -166,7 +166,7 @@ docker compose down
 构建镜像：
 
 ```bash
-docker build -t runzhliu/deepseek-harness:0.1.0-rc.6 .
+docker build -t runzhliu/deepseek-harness:0.1.1-rc.2 .
 ```
 
 启动 Web UI：
@@ -180,7 +180,7 @@ docker run --rm \
   --shm-size 1g \
   --mount type=volume,src=dsh-home,dst=/home/node/.dsh \
   --mount type=bind,src="$PWD",dst=/workspace \
-  runzhliu/deepseek-harness:0.1.0-rc.6
+  runzhliu/deepseek-harness:0.1.1-rc.2
 ```
 
 不要把端口参数改成 `-p 3080:3080`，也不要把它部署到公开 Ingress。那会把一个没有认证、具备代码执行能力的接口暴露给网络。
@@ -194,7 +194,7 @@ docker run --rm \
   --env DEEPSEEK_API_KEY \
   --mount type=volume,src=dsh-home,dst=/home/node/.dsh \
   --mount type=bind,src="$PWD",dst=/workspace \
-  runzhliu/deepseek-harness:0.1.0-rc.6 \
+  runzhliu/deepseek-harness:0.1.1-rc.2 \
   --profile headless "summarize this repository"
 ```
 
@@ -211,7 +211,7 @@ helm upgrade --install deepseek-harness charts/deepseek-harness \
   --namespace deepseek-harness \
   --create-namespace \
   --set image.repository=runzhliu/deepseek-harness \
-  --set image.tag=0.1.0-rc.6
+  --set image.tag=0.1.1-rc.2
 ```
 
 本机开发集群也可以直接拉取默认的 `runzhliu/deepseek-harness`，或先用 `kind load docker-image` / `minikube image load` 导入同名本地镜像。
@@ -250,15 +250,17 @@ kubectl -n deepseek-harness get pvc
 
 ```bash
 docker build \
-  --build-arg DSH_VERSION=0.1.0-rc.6 \
-  -t runzhliu/deepseek-harness:0.1.0-rc.6 .
+  --build-arg DSH_VERSION=0.1.1-rc.2 \
+  -t runzhliu/deepseek-harness:0.1.1-rc.2 .
 ```
 
 Compose 可以使用同一个变量：
 
 ```bash
-DSH_VERSION=0.1.0-rc.6 docker compose build --pull
+DSH_VERSION=0.1.1-rc.2 docker compose build --pull
 ```
+
+维护者可用 `make push` 构建并推送同一个版本标签下的 `linux/amd64` 与 `linux/arm64` manifest。该命令不会创建 `latest` 标签。
 
 不要默认安装 `latest`。RC 版本正在快速变化，固定版本才能让问题可复现。
 
@@ -276,9 +278,9 @@ DSH_VERSION=0.1.0-rc.6 docker compose build --pull
 每次升级至少完成以下检查：
 
 ```bash
-docker run --rm --entrypoint dsh runzhliu/deepseek-harness:0.1.0-rc.6 --version
+docker run --rm --entrypoint dsh runzhliu/deepseek-harness:0.1.1-rc.2 --version
 
-docker run --rm --entrypoint dsh runzhliu/deepseek-harness:0.1.0-rc.6 \
+docker run --rm --entrypoint dsh runzhliu/deepseek-harness:0.1.1-rc.2 \
   web --patch /opt/deepseek-harness/web.cordis.patch.yml --dump-config
 
 docker compose up -d
@@ -287,7 +289,7 @@ docker compose ps
 docker compose logs --no-color deepseek-harness
 ```
 
-通过标准包括：CLI 版本等于构建版本；dump 后的 `webserver.config.host` 为 `0.0.0.0`；首页返回 2xx；容器进入 healthy；日志没有配置或插件加载错误。真正发布镜像前还要分别在 `linux/amd64` 和 `linux/arm64` 上构建并实际 spawn PTY，因为终端与沙箱相关依赖包含原生模块。仓库提供 `make verify`、`make build` 和 `make smoke` 作为统一入口。
+通过标准包括：CLI 版本等于构建版本；dump 后的 `webserver.config.host` 为 `0.0.0.0`；首页返回 2xx；容器进入 healthy；日志没有配置或插件加载错误；容器不会尝试调用宿主默认浏览器。真正发布镜像前还要分别在 `linux/amd64` 和 `linux/arm64` 上构建并实际 spawn PTY，因为终端与沙箱相关依赖包含原生模块。仓库提供 `make verify`、`make build` 和 `make smoke` 作为统一入口。
 
 ## 常见问题
 

--- a/charts/deepseek-harness/Chart.yaml
+++ b/charts/deepseek-harness/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: deepseek-harness
 description: Community Helm chart for a single-user DeepSeek Harness Web instance
 type: application
-version: 0.1.0
-appVersion: "0.1.0-rc.6"
+version: 0.1.1
+appVersion: "0.1.1-rc.2"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/runzhliu/deepseek-harness-docker
 keywords:
@@ -21,7 +21,9 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: deepseek-harness
-      image: runzhliu/deepseek-harness:0.1.0-rc.6
+      image: runzhliu/deepseek-harness:0.1.1-rc.2
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial single-replica StatefulSet deployment.
+    - kind: changed
+      description: Upgrade the default DeepSeek Harness runtime to 0.1.1-rc.2.
+    - kind: fixed
+      description: Disable the upstream automatic browser handoff inside containers.

--- a/charts/deepseek-harness/values.yaml
+++ b/charts/deepseek-harness/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: runzhliu/deepseek-harness
-  tag: 0.1.0-rc.6
+  tag: 0.1.1-rc.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -34,6 +34,7 @@ args:
   - web
   - --patch
   - /opt/deepseek-harness/web.cordis.patch.yml
+  - --no-open
 
 podAnnotations: {}
 podLabels: {}

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,8 +3,8 @@ services:
     build:
       context: .
       args:
-        DSH_VERSION: ${DSH_VERSION:-0.1.0-rc.6}
-    image: runzhliu/deepseek-harness:${DSH_VERSION:-0.1.0-rc.6}
+        DSH_VERSION: ${DSH_VERSION:-0.1.1-rc.2}
+    image: runzhliu/deepseek-harness:${DSH_VERSION:-0.1.1-rc.2}
     ports:
       - "127.0.0.1:${DSH_PORT:-3080}:3080"
       - "127.0.0.1:${DSH_DESKTOP_PORT:-6080}:6080"

--- a/plugins/dsh-browser-desktop/README.md
+++ b/plugins/dsh-browser-desktop/README.md
@@ -21,7 +21,7 @@ For local package testing:
 
 ```bash
 npm pack ./plugins/dsh-browser-desktop --pack-destination /tmp
-dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.0.tgz
+dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.1.tgz
 ```
 
 The package declares a DSH bundle patch, so `dsh plugin` adds the host and Web client halves together. Restart the Web profile after installation.

--- a/plugins/dsh-browser-desktop/package.json
+++ b/plugins/dsh-browser-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runzhliu/dsh-browser-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Movable, resizable Chromium desktop embedded in the DeepSeek Harness Web UI through noVNC.",
   "license": "MIT",
   "type": "module",
@@ -59,9 +59,9 @@
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "peerDependencies": {
-    "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6 || ^0.1.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.6 || ^0.1.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.6 || ^0.1.1-rc.2",
     "react": "^18.2.0"
   }
 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-image="${1:-runzhliu/deepseek-harness:0.1.0-rc.6}"
-expected_version="${2:-0.1.0-rc.6}"
+image="${1:-runzhliu/deepseek-harness:0.1.1-rc.2}"
+expected_version="${2:-0.1.1-rc.2}"
 expected_pnpm_version="${3:-10.15.1}"
 suffix="${RANDOM}-$$"
 container="deepseek-harness-smoke-${suffix}"
@@ -116,6 +116,10 @@ for attempt in $(seq 1 30); do
         .catch(() => process.exit(1))
     '; then
       echo "browser_open transport did not open a Chromium tab" >&2
+      exit 1
+    fi
+    if docker logs "${container}" 2>&1 | grep --quiet 'opening the default browser'; then
+      echo "dsh web attempted to open a host browser; the container command must include --no-open" >&2
       exit 1
     fi
     echo "smoke test passed for ${image} (Harness and noVNC desktop) on 127.0.0.1:${port}"


### PR DESCRIPTION
## Summary

- upgrade the packaged official runtime to `@deepseek-ai/dsh@0.1.1-rc.2`
- pass `--no-open` so the container-managed Chromium/noVNC desktop remains the browser lifecycle owner
- update Compose, Helm, CI, documentation, and the embedded browser plugin compatibility range
- add a reproducible versioned multi-platform Docker Hub push target

## Validation

- `make verify`
- `make build`
- `make smoke`
- `rhysd/actionlint:latest`

The local ARM64 smoke test covered the DSH CLI version, pnpm, node-pty, hardened Chromium, Web UI, noVNC, embedded browser plugin, and browser-open endpoint. CI repeats the image build and smoke test natively on AMD64 and ARM64.

No floating Docker `latest` tag is introduced.
