### PR TITLE
feat: add an optional DSH plugin market image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,12 @@
 *
 !Dockerfile
+!Dockerfile.market
 !web.cordis.patch.yml
+!web.market.cordis.patch.yml
 !scripts/
 !scripts/chromium-docker
 !scripts/deepseek-harness-entrypoint
+!scripts/deepseek-harness-market-entrypoint
 !plugins/
 !plugins/dsh-browser-desktop/
 !plugins/dsh-browser-desktop/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,19 @@ jobs:
           tags: deepseek-harness:ci-${{ matrix.suffix }}
           cache-from: type=gha,scope=${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}
-      - run: ./scripts/smoke.sh deepseek-harness:ci-${{ matrix.suffix }} 0.1.1-rc.2
+      - run: ./scripts/smoke.sh deepseek-harness:ci-${{ matrix.suffix }} 0.1.1-rc.2 10.15.1
+
+  optional-market:
+    name: Optional market smoke (linux/amd64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build --tag deepseek-harness:ci-market-base .
+      - run: >-
+          docker build
+          --file Dockerfile.market
+          --build-arg BASE_IMAGE=deepseek-harness:ci-market-base
+          --tag deepseek-harness:ci-market-amd64
+          .
+      - run: ./scripts/smoke.sh deepseek-harness:ci-market-amd64 0.1.1-rc.2 10.15.1 1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased
+
+- Add an explicitly optional `Dockerfile.market` derived image and Compose overlay that pin the third-party `dshmarket@1.21.0` package.
+- Keep the default Docker target, Compose stack, Helm chart, and DSH Web patch free of the community market.
+- Test the default official-DSH integration separately from the optional market variant, including hardened runtime checks and disabled market-owned restarts.
+
 ## 0.1.1 - 2026-08-24
 
 - Upgrade the official runtime to `@deepseek-ai/dsh@0.1.1-rc.2`.

--- a/Dockerfile.market
+++ b/Dockerfile.market
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.7
+
+ARG NODE_IMAGE=node:24-bookworm-slim
+ARG BASE_IMAGE=runzhliu/deepseek-harness:0.1.1-rc.2
+FROM ${NODE_IMAGE} AS market-installer
+
+ARG DSH_MARKET_VERSION=1.21.0
+
+# Resolve the optional package in isolation. Installing with DSH itself as
+# npm's prefix could prune bundles that DSH owns outside ordinary dependencies.
+RUN mkdir -p /opt/dshmarket \
+    && npm pack --pack-destination /tmp "dshmarket@${DSH_MARKET_VERSION}" \
+    && tar --extract --gzip \
+      --file "/tmp/dshmarket-${DSH_MARKET_VERSION}.tgz" \
+      --strip-components=1 \
+      --directory /opt/dshmarket \
+    && npm install \
+      --prefix /opt/dshmarket \
+      --package-lock=false \
+      --omit=dev \
+      --no-audit \
+      --no-fund \
+      --ignore-scripts \
+      --legacy-peer-deps \
+    && test "$(node -p 'require("/opt/dshmarket/package.json").version')" = "${DSH_MARKET_VERSION}" \
+    && test -f /opt/dshmarket/LICENSE \
+    && rm -f "/tmp/dshmarket-${DSH_MARKET_VERSION}.tgz" \
+    && npm cache clean --force
+
+FROM ${BASE_IMAGE}
+
+ARG DSH_MARKET_VERSION=1.21.0
+ARG MARKET_IMAGE_VERSION=0.1.1-rc.2-market.1
+
+LABEL org.opencontainers.image.version="${MARKET_IMAGE_VERSION}" \
+      io.github.runzhliu.deepseek-harness.variant="community-market" \
+      io.github.runzhliu.deepseek-harness.dshmarket-version="${DSH_MARKET_VERSION}"
+
+COPY --from=market-installer /opt/dshmarket /usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket
+COPY --chown=node:node web.market.cordis.patch.yml /opt/deepseek-harness/web.cordis.patch.yml
+COPY scripts/deepseek-harness-entrypoint /usr/local/bin/deepseek-harness-entrypoint
+COPY scripts/deepseek-harness-market-entrypoint /usr/local/bin/deepseek-harness-market-entrypoint
+
+USER root
+RUN chmod 0755 \
+      /usr/local/bin/deepseek-harness-entrypoint \
+      /usr/local/bin/deepseek-harness-market-entrypoint \
+    && test "$(node -p 'require("/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket/package.json").version')" = "${DSH_MARKET_VERSION}" \
+    && node -e "import('/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket/lib/index.js')"
+USER node
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/deepseek-harness-market-entrypoint"]
+CMD ["--profile", "web", "--patch", "/opt/deepseek-harness/web.cordis.patch.yml", "--no-open"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,19 @@
 IMAGE ?= runzhliu/deepseek-harness
 VERSION ?= 0.1.1-rc.2
+DSH_VERSION ?= $(VERSION)
+DSH_MARKET_VERSION ?= 1.21.0
+MARKET_IMAGE_VERSION ?= $(VERSION)-market.1
 PLATFORMS ?= linux/amd64,linux/arm64
 
-.PHONY: help build multiarch-build push pull up down logs compose-check helm-check plugin-check verify smoke inspect
+.PHONY: help build multiarch-build push pull market-build market-push market-pull up down logs compose-check helm-check plugin-check verify smoke market-smoke inspect market-inspect
 
 help:
 	@echo "build            Build the local platform image"
 	@echo "multiarch-build  Build both release platforms without pushing"
 	@echo "push             Build and push the versioned multi-platform image"
 	@echo "pull             Pull the published image"
+	@echo "market-build     Build the optional community-market image"
+	@echo "market-push      Build and push its versioned multi-platform image"
 	@echo "up/down/logs     Manage the Compose service"
 	@echo "verify           Validate Compose and Helm rendering"
 	@echo "plugin-check     Validate and dry-pack the browser plugin"
@@ -16,16 +21,25 @@ help:
 	@echo "inspect          Inspect the remote multi-platform manifest"
 
 build:
-	docker build --pull --build-arg DSH_VERSION=$(VERSION) --tag $(IMAGE):$(VERSION) .
+	docker build --pull --build-arg DSH_VERSION=$(DSH_VERSION) --tag $(IMAGE):$(VERSION) .
 
 multiarch-build:
-	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(VERSION) --tag $(IMAGE):$(VERSION) .
+	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(DSH_VERSION) --tag $(IMAGE):$(VERSION) .
 
 push:
-	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(VERSION) --tag $(IMAGE):$(VERSION) --push .
+	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(DSH_VERSION) --tag $(IMAGE):$(VERSION) --push .
 
 pull:
 	docker pull $(IMAGE):$(VERSION)
+
+market-build:
+	docker build --pull --file Dockerfile.market --build-arg BASE_IMAGE=$(IMAGE):$(VERSION) --build-arg DSH_MARKET_VERSION=$(DSH_MARKET_VERSION) --build-arg MARKET_IMAGE_VERSION=$(MARKET_IMAGE_VERSION) --tag $(IMAGE):$(MARKET_IMAGE_VERSION) .
+
+market-push:
+	docker buildx build --platform $(PLATFORMS) --file Dockerfile.market --build-arg BASE_IMAGE=$(IMAGE):$(VERSION) --build-arg DSH_MARKET_VERSION=$(DSH_MARKET_VERSION) --build-arg MARKET_IMAGE_VERSION=$(MARKET_IMAGE_VERSION) --tag $(IMAGE):$(MARKET_IMAGE_VERSION) --push .
+
+market-pull:
+	docker pull $(IMAGE):$(MARKET_IMAGE_VERSION)
 
 up:
 	docker compose up --detach --no-build
@@ -38,6 +52,7 @@ logs:
 
 compose-check:
 	docker compose config --quiet
+	docker compose -f compose.yaml -f compose.market.yaml config --quiet
 
 helm-check:
 	helm lint --strict charts/deepseek-harness
@@ -52,7 +67,13 @@ plugin-check:
 verify: compose-check helm-check plugin-check
 
 smoke:
-	./scripts/smoke.sh $(IMAGE):$(VERSION) $(VERSION)
+	./scripts/smoke.sh $(IMAGE):$(VERSION) $(DSH_VERSION) 10.15.1
+
+market-smoke:
+	./scripts/smoke.sh $(IMAGE):$(MARKET_IMAGE_VERSION) $(DSH_VERSION) 10.15.1 $(DSH_MARKET_VERSION)
 
 inspect:
 	docker buildx imagetools inspect $(IMAGE):$(VERSION)
+
+market-inspect:
+	docker buildx imagetools inspect $(IMAGE):$(MARKET_IMAGE_VERSION)

--- a/README.en.md
+++ b/README.en.md
@@ -149,7 +149,30 @@ npm pack ./plugins/dsh-browser-desktop --pack-destination /tmp
 dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.1.tgz
 ```
 
-After npm publication, install it with `dsh plugin --profile web add @runzhliu/dsh-browser-desktop`. The npm package supplies only the Harness host/Web integration; it does not install Chromium, Xvfb, or noVNC. This repository's image is the complete reference runtime. DeepSeek Harness currently discovers community plugins through npm/GitHub and the `dsh-plugin` GitHub topic rather than a curated marketplace submission queue.
+After npm publication, install it with `dsh plugin --profile web add @runzhliu/dsh-browser-desktop`. The npm package supplies only the Harness host/Web integration; it does not install Chromium, Xvfb, or noVNC. This repository's image is the complete reference runtime. Official DSH discovers community plugins through npm/GitHub and the `dsh-plugin` GitHub topic.
+
+### Optional community plugin market
+
+The default image, Compose stack, and Helm chart **do not contain or load a plugin market**; they follow only the official `@deepseek-ai/dsh` distribution. Explicitly select the separate [`dshmarket`](https://github.com/dsh-market/dsh-market) variant when you want a visual community-plugin browser and installer:
+
+```bash
+docker compose -f compose.yaml -f compose.market.yaml pull
+DSH_WORKSPACE=/absolute/path/to/your/project \
+  docker compose -f compose.yaml -f compose.market.yaml up -d --no-build
+```
+
+The variant has the unambiguous `runzhliu/deepseek-harness:0.1.1-rc.2-market.1` tag and pins `dshmarket@1.21.0`; it does not replace the default DSH tag or `latest`. It is an optional community integration, not a DeepSeek component, and neither DeepSeek nor this project audits or endorses catalog entries.
+
+The market package itself is pinned and copied at build time. Plugins installed through it persist in the `dsh-home` volume. Installation needs container egress to npm/GitHub, and third-party build scripts should remain blocked until separately reviewed and approved. One-click market restart is disabled; apply lifecycle changes with `docker compose restart` or a Kubernetes rollout.
+
+Build and test the optional variant locally with:
+
+```bash
+make market-build
+make market-smoke
+```
+
+Helm continues to default to the official-DSH image; it uses the market variant only when you explicitly pass `--set image.tag=0.1.1-rc.2-market.1`.
 
 This public branch packages no company-internal models, credentials, skills, or personal workspace mounts. Configure models in Harness Settings and keep extra credentials or private extensions in runtime Secrets, the ignored `.env`, or a machine-local `compose.local.yaml`.
 
@@ -258,6 +281,8 @@ DSH_VERSION=0.1.1-rc.2 docker compose build --pull
 
 Maintainers can run `make push` to build and publish the `linux/amd64` and `linux/arm64` manifests under the same versioned tag. The target does not create a `latest` tag.
 
+The optional market variant has a separate `make market-push` target. It publishes only the dual-architecture tag carrying the `-market.1` suffix and never changes the default image.
+
 Do not install an unbounded `latest` tag. Release-candidate behavior changes quickly, and exact versions make bugs reproducible.
 
 ## Security boundary
@@ -290,7 +315,7 @@ helm lint --strict charts/deepseek-harness
 helm template deepseek-harness charts/deepseek-harness >/dev/null
 ```
 
-Acceptance criteria: the CLI reports the pinned version; the dumped `webserver.config.host` is `0.0.0.0`; the home page returns 2xx; Compose reaches `healthy`; logs contain no plugin/config errors; the container does not try to hand off to a host browser; and Helm renders both persistent and ephemeral-storage variants. Build both `linux/amd64` and `linux/arm64` and actually spawn a PTY before publishing because terminal and sandbox dependencies include native code. The common entry points are `make verify`, `make build`, and `make smoke`.
+Acceptance criteria: the CLI reports the pinned version; the dumped `webserver.config.host` is `0.0.0.0`; the home page returns 2xx; Compose reaches `healthy`; logs contain no plugin/config errors; the container does not try to hand off to a host browser; and Helm renders both persistent and ephemeral-storage variants. Build both `linux/amd64` and `linux/arm64` and actually spawn a PTY before publishing because terminal and sandbox dependencies include native code. The default entry points are `make verify`, `make build`, and `make smoke`; the optional market uses `make market-build` and `make market-smoke`, which also prove that the market package is absent from the default image.
 
 ## Troubleshooting
 
@@ -309,8 +334,11 @@ The last command must print `/workspace`. An `EACCES` under `/workspace` instead
 | Path | Purpose |
 | --- | --- |
 | `Dockerfile` | Pinned, non-root DSH runtime with Web as the default command |
+| `Dockerfile.market` | Optional derivative that pins a third-party market version on top of the default image |
 | `web.cordis.patch.yml` | Docker-bridge-only Web listener override |
 | `compose.yaml` | Persistent, loopback-only, hardened local deployment |
+| `compose.market.yaml` | Optional Compose overlay that explicitly selects the third-party community market image |
+| `web.market.cordis.patch.yml` | Profile configuration used only by the optional market derivative |
 | `plugins/dsh-browser-desktop/` | Independently publishable DSH browser desktop bundle |
 | `charts/deepseek-harness/` | StatefulSet, PVC, headless Service, and NetworkPolicy |
 | `scripts/smoke.sh` | CLI, config, native PTY, and HTTP startup checks |

--- a/README.md
+++ b/README.md
@@ -148,7 +148,30 @@ npm pack ./plugins/dsh-browser-desktop --pack-destination /tmp
 dsh plugin --profile web add /tmp/runzhliu-dsh-browser-desktop-0.1.1.tgz
 ```
 
-发布到 npm 后可直接执行 `dsh plugin --profile web add @runzhliu/dsh-browser-desktop`。该 npm 包只负责 Harness Host/WebUI 集成，不会自行安装 Chromium、Xvfb 或 noVNC；本仓库 Docker 镜像是完整的参考运行时。DeepSeek Harness 当前通过 npm/GitHub 和 `dsh-plugin` GitHub topic 发现社区插件，并没有单独的审核型插件市场提交流程。
+发布到 npm 后可直接执行 `dsh plugin --profile web add @runzhliu/dsh-browser-desktop`。该 npm 包只负责 Harness Host/WebUI 集成，不会自行安装 Chromium、Xvfb 或 noVNC；本仓库 Docker 镜像是完整的参考运行时。官方 DSH 通过 npm/GitHub 和 `dsh-plugin` GitHub topic 发现社区插件。
+
+### 可选的社区插件市场
+
+默认镜像、默认 Compose 和 Helm Chart **不包含也不加载插件市场**，它们只跟随官方 `@deepseek-ai/dsh` 发行物。需要图形化浏览和安装社区插件时，可以显式选择独立的 [`dshmarket`](https://github.com/dsh-market/dsh-market) 变体：
+
+```bash
+docker compose -f compose.yaml -f compose.market.yaml pull
+DSH_WORKSPACE=/absolute/path/to/your/project \
+  docker compose -f compose.yaml -f compose.market.yaml up -d --no-build
+```
+
+该变体使用明确区分的 `runzhliu/deepseek-harness:0.1.1-rc.2-market.1` 标签，固定 `dshmarket@1.21.0`，不会替换默认 DSH 标签或 `latest`。它属于社区可选集成，不是 DeepSeek 官方组件，也不代表本项目对市场条目的审核或背书。
+
+市场自身在构建期固定并打入可选镜像；通过市场安装的插件会写入持久化的 `dsh-home` 卷。安装过程需要容器能够访问 npm/GitHub，第三方包的构建脚本仍应在审查后单独授权。市场内的一键重启已禁用，变更需要通过 `docker compose restart` 或 Kubernetes rollout 进入新进程。
+
+本地验证可选变体：
+
+```bash
+make market-build
+make market-smoke
+```
+
+Helm 仍默认官方 DSH 镜像；只有明确设置 `--set image.tag=0.1.1-rc.2-market.1` 时才使用市场变体。
 
 本公开分支不打包任何公司内部模型、凭据、Skill 或个人工作区挂载。模型在 Harness 设置页配置；额外凭据和私有扩展应放在运行时 Secret、被忽略的 `.env` 或本机 `compose.local.yaml` 中。
 
@@ -262,6 +285,8 @@ DSH_VERSION=0.1.1-rc.2 docker compose build --pull
 
 维护者可用 `make push` 构建并推送同一个版本标签下的 `linux/amd64` 与 `linux/arm64` manifest。该命令不会创建 `latest` 标签。
 
+可选市场变体使用独立的 `make market-push`，只发布带 `-market.1` 后缀的双架构标签，不改变默认镜像。
+
 不要默认安装 `latest`。RC 版本正在快速变化，固定版本才能让问题可复现。
 
 ## 安全边界
@@ -289,7 +314,7 @@ docker compose ps
 docker compose logs --no-color deepseek-harness
 ```
 
-通过标准包括：CLI 版本等于构建版本；dump 后的 `webserver.config.host` 为 `0.0.0.0`；首页返回 2xx；容器进入 healthy；日志没有配置或插件加载错误；容器不会尝试调用宿主默认浏览器。真正发布镜像前还要分别在 `linux/amd64` 和 `linux/arm64` 上构建并实际 spawn PTY，因为终端与沙箱相关依赖包含原生模块。仓库提供 `make verify`、`make build` 和 `make smoke` 作为统一入口。
+通过标准包括：CLI 版本等于构建版本；dump 后的 `webserver.config.host` 为 `0.0.0.0`；首页返回 2xx；容器进入 healthy；日志没有配置或插件加载错误；容器不会尝试调用宿主默认浏览器。真正发布镜像前还要分别在 `linux/amd64` 和 `linux/arm64` 上构建并实际 spawn PTY，因为终端与沙箱相关依赖包含原生模块。仓库提供 `make verify`、`make build` 和 `make smoke` 作为默认入口；可选市场另用 `make market-build` 和 `make market-smoke`，并额外验证默认镜像中不存在市场包。
 
 ## 常见问题
 
@@ -308,8 +333,11 @@ docker compose exec deepseek-harness node -e "console.log(require('node:os').hom
 | 文件 | 用途 |
 | --- | --- |
 | `Dockerfile` | 固定版本的非 root DSH 运行时，默认启动 Web UI |
+| `Dockerfile.market` | 从默认镜像派生、固定第三方市场版本的可选镜像 |
 | `web.cordis.patch.yml` | 只用于 Docker bridge 网络的 Web 监听覆盖 |
 | `compose.yaml` | 持久化、回环端口和收紧后的运行时配置 |
+| `compose.market.yaml` | 显式选择第三方社区市场镜像的可选 Compose overlay |
+| `web.market.cordis.patch.yml` | 只由可选市场派生镜像使用的 profile 配置 |
 | `plugins/dsh-browser-desktop/` | 可独立发布的 DSH 浏览器桌面 bundle |
 | `charts/deepseek-harness/` | 单副本 StatefulSet、PVC、Service 和 NetworkPolicy |
 | `scripts/smoke.sh` | CLI、配置、原生 PTY 和 HTTP 启动验证 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,8 @@ DeepSeek Harness Web currently has no application authentication or TLS and can 
 
 Public Ingress, LoadBalancer, NodePort, unrestricted `-p 3080:3080`, shared multi-user access, Docker socket mounts, and privileged containers are outside the supported security model.
 
+The optional `market` image variant contains a third-party community catalog and installer. It is not part of the default image and does not imply review or endorsement of listed plugins. Keep package build scripts blocked until reviewed, restrict container egress where practical, and treat every installed plugin as code running with the Harness process's access to the workspace and persisted profile.
+
 ## Reporting
 
 Do not publish credentials, session content, private workspace paths, or exploitable deployment details in a public issue. Report vulnerabilities privately to the repository owner through GitHub Security Advisories. Report vulnerabilities in DeepSeek Harness itself through the upstream project's security channel.

--- a/compose.market.yaml
+++ b/compose.market.yaml
@@ -1,0 +1,9 @@
+services:
+  deepseek-harness:
+    build:
+      dockerfile: Dockerfile.market
+      args:
+        BASE_IMAGE: runzhliu/deepseek-harness:${DSH_VERSION:-0.1.1-rc.2}
+        DSH_MARKET_VERSION: ${DSH_MARKET_VERSION:-1.21.0}
+        MARKET_IMAGE_VERSION: ${MARKET_IMAGE_VERSION:-0.1.1-rc.2-market.1}
+    image: runzhliu/deepseek-harness:${MARKET_IMAGE_VERSION:-0.1.1-rc.2-market.1}

--- a/plugins/dsh-browser-desktop/README.md
+++ b/plugins/dsh-browser-desktop/README.md
@@ -48,7 +48,7 @@ This plugin controls a real browser and its noVNC service has no authentication 
 
 ## Discovery and publishing
 
-DeepSeek Harness currently discovers community plugins through npm/GitHub rather than a curated submission queue. Before publishing, follow the official [bundle publishing guide](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/develop/basic/publish.md), run `npm pack --dry-run`, publish the scoped package with public access, and add the GitHub topic `dsh-plugin` to the repository.
+Official DeepSeek Harness discovers community plugins through npm/GitHub and the `dsh-plugin` topic. The parent container repository also documents an explicitly optional third-party `dshmarket` image variant, but that market is neither an official DeepSeek service nor a substitute for publishing a normal DSH bundle. Before publishing, follow the official [bundle publishing guide](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/develop/basic/publish.md), run `npm pack --dry-run`, publish the scoped package with public access, and add the GitHub topic `dsh-plugin` to the repository.
 
 ## License
 

--- a/scripts/deepseek-harness-entrypoint
+++ b/scripts/deepseek-harness-entrypoint
@@ -144,7 +144,8 @@ trap handle_signal INT TERM HUP
 
 install_browser_plugin
 
-if [ "${1:-}" = "web" ] && [ "${DSH_DESKTOP_ENABLED:-1}" = "1" ]; then
+if { [ "${1:-}" = "web" ] || { [ "${1:-}" = "--profile" ] && [ "${2:-}" = "web" ]; }; } \
+    && [ "${DSH_DESKTOP_ENABLED:-1}" = "1" ]; then
   start_desktop || {
     stop_children
     exit 1

--- a/scripts/deepseek-harness-market-entrypoint
+++ b/scripts/deepseek-harness-market-entrypoint
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+plugin_root="${DSH_HOME}/profiles/web/node_modules"
+plugin_link="${plugin_root}/dshmarket"
+plugin_source=/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket
+
+mkdir -p "${plugin_root}"
+if [ -L "${plugin_link}" ]; then
+  rm -f "${plugin_link}"
+elif [ -e "${plugin_link}" ]; then
+  echo "plugin market path already exists; leaving it unchanged: ${plugin_link}" >&2
+  exec /usr/local/bin/deepseek-harness-entrypoint "$@"
+fi
+ln -s "${plugin_source}" "${plugin_link}"
+
+exec /usr/local/bin/deepseek-harness-entrypoint "$@"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 image="${1:-runzhliu/deepseek-harness:0.1.1-rc.2}"
 expected_version="${2:-0.1.1-rc.2}"
 expected_pnpm_version="${3:-10.15.1}"
+expected_market_version="${4:-}"
 suffix="${RANDOM}-$$"
 container="deepseek-harness-smoke-${suffix}"
 volume="deepseek-harness-smoke-home-${suffix}"
@@ -26,9 +27,35 @@ if [[ "${actual_pnpm_version}" != "${expected_pnpm_version}" ]]; then
   exit 1
 fi
 
-config="$(docker run --rm "${image}" web --patch /opt/deepseek-harness/web.cordis.patch.yml --dump-config)"
+if [[ -n "${expected_market_version}" ]]; then
+  actual_market_version="$(docker run --rm --entrypoint node "${image}" -p \
+    'require("/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket/package.json").version')"
+  if [[ "${actual_market_version}" != "${expected_market_version}" ]]; then
+    echo "expected dshmarket ${expected_market_version}, got ${actual_market_version}" >&2
+    exit 1
+  fi
+elif ! docker run --rm --entrypoint sh "${image}" -c \
+  'test ! -e /usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket'; then
+  echo "the default DSH image unexpectedly contains the optional community market" >&2
+  exit 1
+fi
+
+if [[ -n "${expected_market_version}" ]]; then
+  config="$(docker run --rm "${image}" --profile web --patch /opt/deepseek-harness/web.cordis.patch.yml --dump-config)"
+else
+  config="$(docker run --rm "${image}" web --patch /opt/deepseek-harness/web.cordis.patch.yml --dump-config)"
+fi
 if [[ "${config}" != *"host: 0.0.0.0"* && "${config}" != *"host: '0.0.0.0'"* ]]; then
   echo "container Web patch did not set host to 0.0.0.0" >&2
+  exit 1
+fi
+if [[ -n "${expected_market_version}" ]]; then
+  if [[ "${config}" != *"name: dshmarket"* ]]; then
+    echo "optional market image did not load dshmarket" >&2
+    exit 1
+  fi
+elif [[ "${config}" == *"name: dshmarket"* ]]; then
+  echo "the default DSH Web patch unexpectedly loads the community market" >&2
   exit 1
 fi
 
@@ -83,10 +110,20 @@ docker run --detach \
   "${image}" >/dev/null
 
 port="$(docker port "${container}" 3080/tcp | awk -F: 'NR == 1 { print $NF }')"
+
+market_is_ready() {
+  if [[ -z "${expected_market_version}" ]]; then
+    return 0
+  fi
+  docker exec "${container}" node -e \
+    "fetch('http://127.0.0.1:3080/dsh-market/status').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"
+}
+
 for attempt in $(seq 1 30); do
   if curl --fail --silent "http://127.0.0.1:${port}/" >/dev/null \
       && docker exec "${container}" node -e \
-        "Promise.all([fetch('http://127.0.0.1:6080/vnc.html'), fetch('http://127.0.0.1:9222/json/version'), fetch('http://127.0.0.1:3080/browser-desktop/state')]).then(rs => { if (rs.some(r => !r.ok)) process.exit(1) }).catch(() => process.exit(1))"; then
+        "Promise.all([fetch('http://127.0.0.1:6080/vnc.html'), fetch('http://127.0.0.1:9222/json/version'), fetch('http://127.0.0.1:3080/browser-desktop/state')]).then(rs => { if (rs.some(r => !r.ok)) process.exit(1) }).catch(() => process.exit(1))" \
+      && market_is_ready; then
     if ! curl --fail --silent "http://127.0.0.1:${port}/" \
       | grep --quiet '"id":"@runzhliu/dsh-browser-desktop"'; then
       echo "Harness boot manifest did not include the browser desktop client plugin" >&2
@@ -102,6 +139,24 @@ for attempt in $(seq 1 30); do
     '; then
       echo "browser desktop state did not expose its noVNC endpoint" >&2
       exit 1
+    fi
+    if [[ -n "${expected_market_version}" ]]; then
+      if ! curl --fail --silent "http://127.0.0.1:${port}/" \
+        | grep --quiet 'dshmarket'; then
+        echo "Harness boot manifest did not include the plugin market client" >&2
+        exit 1
+      fi
+      if ! docker exec "${container}" node -e "
+        fetch('http://127.0.0.1:3080/dsh-market/status')
+          .then(response => response.json())
+          .then(status => {
+            if (status.version !== '${expected_market_version}' || status.restart !== false) process.exit(1)
+          })
+          .catch(() => process.exit(1))
+      "; then
+        echo "plugin market status did not report the pinned version with self-restart disabled" >&2
+        exit 1
+      fi
     fi
     if ! docker exec "${container}" node -e '
       fetch("http://127.0.0.1:3080/browser-desktop/open", {
@@ -122,7 +177,12 @@ for attempt in $(seq 1 30); do
       echo "dsh web attempted to open a host browser; the container command must include --no-open" >&2
       exit 1
     fi
-    echo "smoke test passed for ${image} (Harness and noVNC desktop) on 127.0.0.1:${port}"
+    if [[ -n "${expected_market_version}" ]]; then
+      features="Harness, optional plugin market, and noVNC desktop"
+    else
+      features="official Harness integration and noVNC desktop"
+    fi
+    echo "smoke test passed for ${image} (${features}) on 127.0.0.1:${port}"
     exit 0
   fi
   if ! docker container inspect "${container}" >/dev/null 2>&1; then

--- a/web.market.cordis.patch.yml
+++ b/web.market.cordis.patch.yml
@@ -1,0 +1,19 @@
+# Keep the official Web patch intact and add the optional package as one more
+# profile row. The image entrypoint supplies its profile-local package link.
+- insert:
+    - id: browser-desktop
+      name: '@runzhliu/dsh-browser-desktop'
+      config:
+        cdpBaseUrl: 'http://127.0.0.1:9222'
+        desktopPort: !!js Number(process.env.DSH_DESKTOP_PUBLIC_PORT ?? 6080)
+    - id: dsh-market
+      name: dshmarket
+      config:
+        # The container entrypoint and orchestrator own the DSH lifecycle.
+        allowRestart: false
+
+- id: webserver
+  name: '@deepseek-ai/dsh-host-webserver'
+  config:
+    host: '0.0.0.0'
+    port: !!js ctx.webStartup.port ?? 3080


### PR DESCRIPTION
## Summary
- keep the default image, Compose stack, Helm chart, and Web patch aligned with official DSH only
- add a separate Dockerfile.market derivative and Compose overlay pinned to dshmarket 1.21.0
- validate default-market separation, hardened browser runtime, market status, and disabled self-restart

## Validation
- make verify
- make build && make smoke
- make market-build && make market-smoke
- actionlint