### PR TITLE
fix: migrate optional market profiles safely

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 !scripts/chromium-docker
 !scripts/deepseek-harness-entrypoint
 !scripts/deepseek-harness-market-entrypoint
+!scripts/dsh-market-repair-store
 !plugins/
 !plugins/dsh-browser-desktop/
 !plugins/dsh-browser-desktop/**

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .DS_Store
 *.log
 .bash_history
+.dsh-doctor/
+.local/
 
 # Machine-local Compose mounts and private extensions are never published.
 compose.local.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project are documented here.
 - Add an explicitly optional `Dockerfile.market` derived image and Compose overlay that pin the third-party `dshmarket@1.21.0` package.
 - Keep the default Docker target, Compose stack, Helm chart, and DSH Web patch free of the community market.
 - Test the default official-DSH integration separately from the optional market variant, including hardened runtime checks and disabled market-owned restarts.
+- Keep the optional variant's pnpm store in `dsh-home` and provide an explicit, backed-up migration for profiles created by a different pnpm major.
+- Repair only a non-writable regular `cordis.patch.yml` with a byte-equivalent, current-user-owned copy so plugin toggles work after reusing volumes created under another UID.
 
 ## 0.1.1 - 2026-08-24
 

--- a/Dockerfile.market
+++ b/Dockerfile.market
@@ -40,14 +40,18 @@ COPY --from=market-installer /opt/dshmarket /usr/local/lib/node_modules/@deepsee
 COPY --chown=node:node web.market.cordis.patch.yml /opt/deepseek-harness/web.cordis.patch.yml
 COPY scripts/deepseek-harness-entrypoint /usr/local/bin/deepseek-harness-entrypoint
 COPY scripts/deepseek-harness-market-entrypoint /usr/local/bin/deepseek-harness-market-entrypoint
+COPY scripts/dsh-market-repair-store /usr/local/bin/dsh-market-repair-store
 
 USER root
 RUN chmod 0755 \
       /usr/local/bin/deepseek-harness-entrypoint \
       /usr/local/bin/deepseek-harness-market-entrypoint \
+      /usr/local/bin/dsh-market-repair-store \
     && test "$(node -p 'require("/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket/package.json").version')" = "${DSH_MARKET_VERSION}" \
     && node -e "import('/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket/lib/index.js')"
 USER node
+
+ENV npm_config_store_dir=/home/node/.dsh/pnpm-store
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/deepseek-harness-market-entrypoint"]
 CMD ["--profile", "web", "--patch", "/opt/deepseek-harness/web.cordis.patch.yml", "--no-open"]

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ helm-check:
 plugin-check:
 	node --check plugins/dsh-browser-desktop/index.js
 	node --check plugins/dsh-browser-desktop/client.js
+	node --check scripts/dsh-market-repair-store
+	sh -n scripts/deepseek-harness-entrypoint
+	sh -n scripts/deepseek-harness-market-entrypoint
+	bash -n scripts/smoke.sh
 	npm --cache "$${TMPDIR:-/tmp}/dsh-browser-plugin-npm-cache" pack --dry-run --json ./plugins/dsh-browser-desktop >/dev/null
 
 verify: compose-check helm-check plugin-check

--- a/README.en.md
+++ b/README.en.md
@@ -163,7 +163,7 @@ DSH_WORKSPACE=/absolute/path/to/your/project \
 
 The variant has the unambiguous `runzhliu/deepseek-harness:0.1.1-rc.2-market.1` tag and pins `dshmarket@1.21.0`; it does not replace the default DSH tag or `latest`. It is an optional community integration, not a DeepSeek component, and neither DeepSeek nor this project audits or endorses catalog entries.
 
-The market package itself is pinned and copied at build time. Plugins installed through it persist in the `dsh-home` volume. Installation needs container egress to npm/GitHub, and third-party build scripts should remain blocked until separately reviewed and approved. One-click market restart is disabled; apply lifecycle changes with `docker compose restart` or a Kubernetes rollout.
+The market package itself is pinned and copied at build time. Plugins installed through it and the pnpm store persist in the `dsh-home` volume. Installation needs container egress to npm/GitHub, and third-party build scripts should remain blocked until separately reviewed and approved. One-click market restart is disabled; apply lifecycle changes with `docker compose restart` or a Kubernetes rollout.
 
 Build and test the optional variant locally with:
 
@@ -173,6 +173,19 @@ make market-smoke
 ```
 
 Helm continues to default to the official-DSH image; it uses the market variant only when you explicitly pass `--set image.tag=0.1.1-rc.2-market.1`.
+
+A reused `dsh-home` previously managed by another pnpm major can fail installation with `ERR_PNPM_UNEXPECTED_STORE`. Stop DSH and run the explicit one-time migration:
+
+```bash
+docker compose -f compose.yaml -f compose.market.yaml stop deepseek-harness
+docker compose -f compose.yaml -f compose.market.yaml run --rm --no-deps \
+  --entrypoint dsh-market-repair-store deepseek-harness
+docker compose -f compose.yaml -f compose.market.yaml up -d --no-build
+```
+
+The migration relinks only dependencies declared by the existing `package.json`, pins the store under `/home/node/.dsh/pnpm-store`, and passes `--ignore-scripts`. It retains the previous `node_modules` under `/home/node/.dsh/backups/pnpm-store-*`; remove that backup yourself only after verifying the plugins.
+
+On startup, the optional entrypoint also repairs an existing non-writable regular `profiles/web/cordis.patch.yml` by replacing it with a byte-equivalent copy owned by the runtime user. This handles volumes previously written under another UID without recursively changing ownership; symbolic links and non-regular files are left untouched with a warning.
 
 This public branch packages no company-internal models, credentials, skills, or personal workspace mounts. Configure models in Harness Settings and keep extra credentials or private extensions in runtime Secrets, the ignored `.env`, or a machine-local `compose.local.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ DSH_WORKSPACE=/absolute/path/to/your/project \
 
 该变体使用明确区分的 `runzhliu/deepseek-harness:0.1.1-rc.2-market.1` 标签，固定 `dshmarket@1.21.0`，不会替换默认 DSH 标签或 `latest`。它属于社区可选集成，不是 DeepSeek 官方组件，也不代表本项目对市场条目的审核或背书。
 
-市场自身在构建期固定并打入可选镜像；通过市场安装的插件会写入持久化的 `dsh-home` 卷。安装过程需要容器能够访问 npm/GitHub，第三方包的构建脚本仍应在审查后单独授权。市场内的一键重启已禁用，变更需要通过 `docker compose restart` 或 Kubernetes rollout 进入新进程。
+市场自身在构建期固定并打入可选镜像；通过市场安装的插件和 pnpm store 会写入持久化的 `dsh-home` 卷。安装过程需要容器能够访问 npm/GitHub，第三方包的构建脚本仍应在审查后单独授权。市场内的一键重启已禁用，变更需要通过 `docker compose restart` 或 Kubernetes rollout 进入新进程。
 
 本地验证可选变体：
 
@@ -172,6 +172,19 @@ make market-smoke
 ```
 
 Helm 仍默认官方 DSH 镜像；只有明确设置 `--set image.tag=0.1.1-rc.2-market.1` 时才使用市场变体。
+
+如果复用的 `dsh-home` 曾被另一个 pnpm 主版本处理，安装时可能看到 `ERR_PNPM_UNEXPECTED_STORE`。先停止 DSH，再显式执行一次迁移：
+
+```bash
+docker compose -f compose.yaml -f compose.market.yaml stop deepseek-harness
+docker compose -f compose.yaml -f compose.market.yaml run --rm --no-deps \
+  --entrypoint dsh-market-repair-store deepseek-harness
+docker compose -f compose.yaml -f compose.market.yaml up -d --no-build
+```
+
+迁移只按现有 `package.json` 重新链接依赖，固定使用 `/home/node/.dsh/pnpm-store`，并传入 `--ignore-scripts`。旧的 `node_modules` 会保留在 `/home/node/.dsh/backups/pnpm-store-*`，确认插件正常后再自行清理。
+
+可选镜像启动时还会检查已有的 `profiles/web/cordis.patch.yml`：如果它是普通文件但因旧 UID 不可写，入口脚本会用内容完全相同、归当前运行用户所有的副本替换它，从而恢复插件开关；不会递归修改整个卷，符号链接或非普通文件只会给出警告。
 
 本公开分支不打包任何公司内部模型、凭据、Skill 或个人工作区挂载。模型在 Harness 设置页配置；额外凭据和私有扩展应放在运行时 Secret、被忽略的 `.env` 或本机 `compose.local.yaml` 中。
 

--- a/scripts/deepseek-harness-market-entrypoint
+++ b/scripts/deepseek-harness-market-entrypoint
@@ -1,9 +1,43 @@
 #!/bin/sh
 set -eu
 
-plugin_root="${DSH_HOME}/profiles/web/node_modules"
+profile="${DSH_PROFILE:-web}"
+case "${profile}" in
+  ''|.|..|*[!A-Za-z0-9._-]*)
+    echo "invalid DSH_PROFILE: ${profile}" >&2
+    exit 1
+    ;;
+esac
+
+profile_root="${DSH_HOME}/profiles/${profile}"
+profile_patch="${profile_root}/cordis.patch.yml"
+plugin_root="${profile_root}/node_modules"
 plugin_link="${plugin_root}/dshmarket"
 plugin_source=/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket
+
+repair_profile_patch_owner() {
+  if [ ! -e "${profile_patch}" ] || [ -w "${profile_patch}" ]; then
+    return 0
+  fi
+  if [ -L "${profile_patch}" ] || [ ! -f "${profile_patch}" ] || [ ! -w "${profile_root}" ]; then
+    echo "plugin toggles need a writable regular file: ${profile_patch}" >&2
+    return 0
+  fi
+
+  repair_path="${profile_root}/.cordis.patch.yml.repair.$$"
+  umask 077
+  if cp -- "${profile_patch}" "${repair_path}" \
+      && chmod 0644 "${repair_path}" \
+      && cmp -s -- "${profile_patch}" "${repair_path}" \
+      && mv -f -- "${repair_path}" "${profile_patch}"; then
+    echo "replaced a read-only profile patch with an equivalent writable copy: ${profile_patch}" >&2
+  else
+    rm -f -- "${repair_path}"
+    echo "could not make the profile patch writable: ${profile_patch}" >&2
+  fi
+}
+
+repair_profile_patch_owner
 
 mkdir -p "${plugin_root}"
 if [ -L "${plugin_link}" ]; then
@@ -13,5 +47,9 @@ elif [ -e "${plugin_link}" ]; then
   exec /usr/local/bin/deepseek-harness-entrypoint "$@"
 fi
 ln -s "${plugin_source}" "${plugin_link}"
+
+if ! dsh-market-repair-store --check >/dev/null; then
+  echo "plugin installs need a one-time pnpm store migration; run dsh-market-repair-store while DSH is stopped" >&2
+fi
 
 exec /usr/local/bin/deepseek-harness-entrypoint "$@"

--- a/scripts/dsh-market-repair-store
+++ b/scripts/dsh-market-repair-store
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const checkOnly = process.argv.includes('--check')
+const dshHome = process.env.DSH_HOME ?? '/home/node/.dsh'
+const profile = process.env.DSH_PROFILE ?? 'web'
+
+if (!/^[A-Za-z0-9._-]+$/.test(profile) || profile === '.' || profile === '..') {
+  throw new Error(`invalid DSH_PROFILE: ${JSON.stringify(profile)}`)
+}
+
+const profileDir = join(dshHome, 'profiles', profile)
+const modulesDir = join(profileDir, 'node_modules')
+const modulesYaml = join(modulesDir, '.modules.yaml')
+const storeRoot = process.env.npm_config_store_dir ?? join(dshHome, 'pnpm-store')
+
+function pathExists(path) {
+  try {
+    lstatSync(path)
+    return true
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+function modulesStore(path) {
+  const source = readFileSync(path, 'utf8')
+  try {
+    const value = JSON.parse(source).storeDir
+    return typeof value === 'string' ? value : null
+  } catch {
+    const match = /^\s*storeDir:\s*(.*?)\s*$/m.exec(source)
+    if (match === null) return null
+    const value = match[1]
+    if (value.startsWith('"') && value.endsWith('"')) {
+      return JSON.parse(value)
+    }
+    if (value.startsWith("'") && value.endsWith("'")) {
+      return value.slice(1, -1).replaceAll("''", "'")
+    }
+    return value
+  }
+}
+
+function pnpmStorePath() {
+  const result = spawnSync('pnpm', ['--store-dir', storeRoot, 'store', 'path'], {
+    encoding: 'utf8',
+    env: { ...process.env, npm_config_store_dir: storeRoot },
+  })
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr)
+    throw new Error('could not resolve the pnpm store path')
+  }
+  return result.stdout.trim()
+}
+
+function topLevelSymlinks(root) {
+  if (!existsSync(root)) return []
+  const links = []
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue
+    const first = join(root, entry.name)
+    if (entry.isSymbolicLink()) {
+      links.push({ path: first, target: readlinkSync(first) })
+      continue
+    }
+    if (!entry.name.startsWith('@') || !entry.isDirectory()) continue
+    for (const child of readdirSync(first, { withFileTypes: true })) {
+      const second = join(first, child.name)
+      if (child.isSymbolicLink()) {
+        links.push({ path: second, target: readlinkSync(second) })
+      }
+    }
+  }
+  return links
+}
+
+if (!existsSync(modulesYaml)) {
+  console.log(`profile ${profile} has no pnpm store metadata; no migration is needed`)
+  process.exit(0)
+}
+
+const linkedStore = modulesStore(modulesYaml)
+const wantedStore = pnpmStorePath()
+if (linkedStore === wantedStore) {
+  console.log(`profile ${profile} already uses ${wantedStore}`)
+  process.exit(0)
+}
+
+console.error(`profile ${profile} uses ${linkedStore ?? 'an unknown store'}`)
+console.error(`the optional market image uses ${wantedStore}`)
+if (checkOnly) process.exit(2)
+
+const timestamp = new Date().toISOString().replaceAll(/[:.]/g, '-')
+const backupDir = join(dshHome, 'backups', `pnpm-store-${profile}-${timestamp}`)
+const backupModules = join(backupDir, 'node_modules')
+const metadata = ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml']
+const originalFiles = new Map()
+const links = topLevelSymlinks(modulesDir)
+
+mkdirSync(backupDir, { recursive: true, mode: 0o700 })
+for (const name of metadata) {
+  const source = join(profileDir, name)
+  const present = existsSync(source)
+  originalFiles.set(name, present)
+  if (present) copyFileSync(source, join(backupDir, name))
+}
+writeFileSync(join(backupDir, 'top-level-symlinks.json'), `${JSON.stringify(links, null, 2)}\n`, { mode: 0o600 })
+renameSync(modulesDir, backupModules)
+
+const install = spawnSync(
+  'pnpm',
+  ['install', '--force', '--store-dir', storeRoot, '--ignore-scripts', '--no-frozen-lockfile'],
+  {
+    cwd: profileDir,
+    env: { ...process.env, CI: 'true', npm_config_store_dir: storeRoot },
+    stdio: 'inherit',
+  },
+)
+
+if (install.status !== 0) {
+  if (existsSync(modulesDir)) rmSync(modulesDir, { recursive: true, force: true })
+  renameSync(backupModules, modulesDir)
+  for (const name of metadata) {
+    const target = join(profileDir, name)
+    if (originalFiles.get(name)) {
+      copyFileSync(join(backupDir, name), target)
+    } else if (existsSync(target)) {
+      rmSync(target)
+    }
+  }
+  throw new Error(`pnpm store migration failed; the original profile was restored from ${backupDir}`)
+}
+
+for (const link of links) {
+  if (pathExists(link.path)) continue
+  mkdirSync(dirname(link.path), { recursive: true })
+  symlinkSync(link.target, link.path)
+}
+
+const migratedStore = existsSync(modulesYaml) ? modulesStore(modulesYaml) : null
+if (migratedStore !== null && migratedStore !== wantedStore) {
+  throw new Error(`pnpm reported success but recorded ${migratedStore ?? 'no store'} instead of ${wantedStore}`)
+}
+
+if (migratedStore === null) {
+  console.log(`profile ${profile} has no pnpm-managed dependencies after migration`)
+} else {
+  console.log(`migrated profile ${profile} to ${wantedStore}`)
+}
+console.log(`the previous node_modules remains available at ${backupModules}`)

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -96,6 +96,20 @@ if [[ "${browser_dom}" != *"DSH_BROWSER_OK"* ]]; then
 fi
 
 docker volume create "${volume}" >/dev/null
+if [[ -n "${expected_market_version}" ]]; then
+  docker run --rm \
+    --user root \
+    --volume "${volume}:/home/node/.dsh" \
+    --entrypoint sh \
+    "${image}" -c '
+      mkdir -p /home/node/.dsh/profiles/web
+      printf "[]\n" >/home/node/.dsh/profiles/web/cordis.patch.yml
+      chown 123456:0 /home/node/.dsh/profiles/web/cordis.patch.yml
+      chmod 0644 /home/node/.dsh/profiles/web/cordis.patch.yml
+      chown -R 1000:1000 /home/node/.dsh
+      chown 123456:0 /home/node/.dsh/profiles/web/cordis.patch.yml
+    '
+fi
 docker run --detach \
   --name "${container}" \
   --publish 127.0.0.1::3080 \
@@ -155,6 +169,54 @@ for attempt in $(seq 1 30); do
           .catch(() => process.exit(1))
       "; then
         echo "plugin market status did not report the pinned version with self-restart disabled" >&2
+        exit 1
+      fi
+      market_store="$(docker exec "${container}" pnpm store path)"
+      if [[ "${market_store}" != /home/node/.dsh/pnpm-store/v* ]]; then
+        echo "optional market image did not use its persistent pnpm store: ${market_store}" >&2
+        exit 1
+      fi
+      if ! docker exec "${container}" dsh-market-repair-store --check >/dev/null; then
+        echo "fresh optional market profile unexpectedly needs a pnpm store migration" >&2
+        exit 1
+      fi
+      if ! docker exec "${container}" sh -c 'test -w "$DSH_HOME/profiles/web/cordis.patch.yml"'; then
+        echo "optional market entrypoint did not repair a read-only profile patch" >&2
+        exit 1
+      fi
+      docker exec \
+        --env DSH_HOME=/tmp/dsh-market-repair-test \
+        --env npm_config_store_dir=/tmp/dsh-market-repair-store \
+        "${container}" node -e '
+          const fs = require("node:fs")
+          const root = process.env.DSH_HOME
+          const modules = `${root}/profiles/web/node_modules`
+          fs.rmSync(root, { recursive: true, force: true })
+          fs.mkdirSync(modules, { recursive: true })
+          fs.mkdirSync(`${root}/local-package`)
+          fs.writeFileSync(`${root}/local-package/package.json`, "{\"name\":\"local-package\",\"version\":\"1.0.0\"}\n")
+          fs.writeFileSync(`${root}/profiles/web/package.json`, "{\"name\":\"market-repair-smoke\",\"private\":true,\"dependencies\":{\"local-package\":\"file:../../local-package\"}}\n")
+          fs.writeFileSync(`${modules}/.modules.yaml`, "storeDir: /tmp/old-pnpm-store/v11\n")
+          fs.mkdirSync(`${root}/unmanaged-plugin`)
+          fs.symlinkSync(`${root}/unmanaged-plugin`, `${modules}/unmanaged-plugin`)
+        '
+      docker exec \
+        --env DSH_HOME=/tmp/dsh-market-repair-test \
+        --env npm_config_store_dir=/tmp/dsh-market-repair-store \
+        "${container}" dsh-market-repair-store >/dev/null
+      if ! docker exec \
+        --env DSH_HOME=/tmp/dsh-market-repair-test \
+        "${container}" node -e '
+          const fs = require("node:fs")
+          const root = process.env.DSH_HOME
+          const metadata = fs.readFileSync(`${root}/profiles/web/node_modules/.modules.yaml`, "utf8")
+          const backups = fs.readdirSync(`${root}/backups`)
+          if (!metadata.includes("/tmp/dsh-market-repair-store/v10")) process.exit(1)
+          if (fs.readlinkSync(`${root}/profiles/web/node_modules/unmanaged-plugin`) !== `${root}/unmanaged-plugin`) process.exit(1)
+          if (!fs.existsSync(`${root}/profiles/web/node_modules/local-package/package.json`)) process.exit(1)
+          if (backups.length !== 1 || !fs.existsSync(`${root}/backups/${backups[0]}/node_modules/.modules.yaml`)) process.exit(1)
+        '; then
+        echo "optional market pnpm store migration did not preserve its backup and external plugin link" >&2
         exit 1
       fi
     fi


### PR DESCRIPTION
## Summary
- keep the optional market pnpm store inside the persistent dsh-home volume
- add an explicit backed-up migration for profiles linked by a different pnpm major
- repair a non-writable regular profile patch with a byte-equivalent runtime-user-owned copy
- cover both legacy-store migration and mismatched-UID profile files in market smoke tests

## Validation
- make verify
- make smoke
- make market-build
- make market-smoke
- live install of @linxin666/dsh-web-ui-all 0.3.2
- live container recreated healthy with plugin state preserved

The default Docker image, Compose stack, and Helm defaults remain market-free.