### PR TITLE
feat: use Trixie non-slim for the default runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 # Exact official @deepseek-ai/dsh version packaged by the image.
-DSH_VERSION=0.1.0-rc.6
+DSH_VERSION=0.1.1-rc.2
+
+# Official Node image used by both the default and optional-market builders.
+# Trixie provides glibc 2.41; the non-slim variant includes common build tools.
+NODE_IMAGE=node:24-trixie
 
 # Host loopback port. Do not change the bind address in compose.yaml.
 DSH_PORT=3080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Change the default builder and runtime base from `node:24-bookworm-slim` to the official non-slim `node:24-trixie`, raising the runtime from glibc 2.36 to 2.41.
+- Keep the buildpack-deps compiler toolchain available to coding-agent and native-plugin workflows, and add an explicit common CLI contract including `jq`, `less`, `ripgrep`, `rsync`, and `zip`.
+- Extend the image smoke test to reject a non-Trixie base, an unexpected glibc version, or any missing required Agent command on both release architectures.
 - Add an explicitly optional `Dockerfile.market` derived image and Compose overlay that pin the third-party `dshmarket@1.21.0` package.
 - Keep the default Docker target, Compose stack, Helm chart, and DSH Web patch free of the community market.
 - Test the default official-DSH integration separately from the optional market variant, including hardened runtime checks and disabled market-owned restarts.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # syntax=docker/dockerfile:1.7
 
-ARG NODE_IMAGE=node:24-bookworm-slim
+ARG NODE_IMAGE=node:24-trixie
 FROM ${NODE_IMAGE} AS installer
 
 ARG DSH_VERSION=0.1.1-rc.2
 ARG PNPM_VERSION=10.15.1
 
-# node-pty publishes prebuilds for only some Linux architectures. Keep a
-# compiler in this stage so linux/arm64 can fall back to node-gyp without
-# carrying build-essential into the runtime image.
+# node-pty publishes prebuilds for only some Linux architectures. Keep the
+# installer requirements explicit so linux/arm64 can fall back to node-gyp,
+# even if a maintainer experiments with another NODE_IMAGE. The default
+# non-slim runtime separately retains its development toolchain on purpose.
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
       build-essential \
@@ -25,6 +26,7 @@ RUN apt-get update \
 
 FROM ${NODE_IMAGE}
 
+ARG NODE_IMAGE
 ARG DSH_VERSION=0.1.1-rc.2
 ARG PNPM_VERSION=10.15.1
 
@@ -34,31 +36,44 @@ LABEL org.opencontainers.image.title="DeepSeek Harness Docker (Community)" \
       org.opencontainers.image.url="https://github.com/runzhliu/deepseek-harness-docker" \
       org.opencontainers.image.documentation="https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-runtime-containerization/" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.version="${DSH_VERSION}"
+      org.opencontainers.image.version="${DSH_VERSION}" \
+      io.github.runzhliu.deepseek-harness.base-image="${NODE_IMAGE}" \
+      io.github.runzhliu.deepseek-harness.debian-codename="trixie"
 
-# Keep the runtime useful to a coding agent without shipping a compiler
-# toolchain. Chromium is installed from Debian so both linux/amd64 and
-# linux/arm64 stay native; the reference linuxserver/chrome base is amd64-only.
-# Noto CJK keeps Chinese pages and screenshots readable.
+# Use Node's official non-slim Trixie variant intentionally: its buildpack-deps
+# base provides the compiler and common development utilities a coding agent or
+# native plugin may need at runtime, while glibc 2.41 accepts newer binaries
+# than Bookworm's glibc 2.36. Install the remaining user-facing CLI tools
+# explicitly so their availability is covered by the smoke test. Chromium is
+# installed from Debian so linux/amd64 and linux/arm64 stay native; Noto CJK
+# keeps Chinese pages and screenshots readable.
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
       ca-certificates \
       chromium \
+      curl \
+      file \
       fonts-liberation \
       fonts-noto-cjk \
       git \
+      jq \
+      less \
       novnc \
       openbox \
       openssh-client \
       procps \
       python3 \
       ripgrep \
+      rsync \
       tini \
+      unzip \
       websockify \
+      wget \
       x11-utils \
       x11vnc \
       xterm \
       xvfb \
+      zip \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /usr/local/lib/node_modules/@deepseek-ai
 

--- a/Dockerfile.market
+++ b/Dockerfile.market
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG NODE_IMAGE=node:24-bookworm-slim
+ARG NODE_IMAGE=node:24-trixie
 ARG BASE_IMAGE=runzhliu/deepseek-harness:0.1.1-rc.2
 FROM ${NODE_IMAGE} AS market-installer
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 IMAGE ?= runzhliu/deepseek-harness
 VERSION ?= 0.1.1-rc.2
 DSH_VERSION ?= $(VERSION)
+NODE_IMAGE ?= node:24-trixie
 DSH_MARKET_VERSION ?= 1.21.0
 MARKET_IMAGE_VERSION ?= $(VERSION)-market.1
 PLATFORMS ?= linux/amd64,linux/arm64
@@ -21,22 +22,22 @@ help:
 	@echo "inspect          Inspect the remote multi-platform manifest"
 
 build:
-	docker build --pull --build-arg DSH_VERSION=$(DSH_VERSION) --tag $(IMAGE):$(VERSION) .
+	docker build --pull --build-arg DSH_VERSION=$(DSH_VERSION) --build-arg NODE_IMAGE=$(NODE_IMAGE) --tag $(IMAGE):$(VERSION) .
 
 multiarch-build:
-	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(DSH_VERSION) --tag $(IMAGE):$(VERSION) .
+	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(DSH_VERSION) --build-arg NODE_IMAGE=$(NODE_IMAGE) --tag $(IMAGE):$(VERSION) .
 
 push:
-	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(DSH_VERSION) --tag $(IMAGE):$(VERSION) --push .
+	docker buildx build --platform $(PLATFORMS) --build-arg DSH_VERSION=$(DSH_VERSION) --build-arg NODE_IMAGE=$(NODE_IMAGE) --tag $(IMAGE):$(VERSION) --push .
 
 pull:
 	docker pull $(IMAGE):$(VERSION)
 
 market-build:
-	docker build --pull --file Dockerfile.market --build-arg BASE_IMAGE=$(IMAGE):$(VERSION) --build-arg DSH_MARKET_VERSION=$(DSH_MARKET_VERSION) --build-arg MARKET_IMAGE_VERSION=$(MARKET_IMAGE_VERSION) --tag $(IMAGE):$(MARKET_IMAGE_VERSION) .
+	docker build --pull --file Dockerfile.market --build-arg BASE_IMAGE=$(IMAGE):$(VERSION) --build-arg NODE_IMAGE=$(NODE_IMAGE) --build-arg DSH_MARKET_VERSION=$(DSH_MARKET_VERSION) --build-arg MARKET_IMAGE_VERSION=$(MARKET_IMAGE_VERSION) --tag $(IMAGE):$(MARKET_IMAGE_VERSION) .
 
 market-push:
-	docker buildx build --platform $(PLATFORMS) --file Dockerfile.market --build-arg BASE_IMAGE=$(IMAGE):$(VERSION) --build-arg DSH_MARKET_VERSION=$(DSH_MARKET_VERSION) --build-arg MARKET_IMAGE_VERSION=$(MARKET_IMAGE_VERSION) --tag $(IMAGE):$(MARKET_IMAGE_VERSION) --push .
+	docker buildx build --platform $(PLATFORMS) --file Dockerfile.market --build-arg BASE_IMAGE=$(IMAGE):$(VERSION) --build-arg NODE_IMAGE=$(NODE_IMAGE) --build-arg DSH_MARKET_VERSION=$(DSH_MARKET_VERSION) --build-arg MARKET_IMAGE_VERSION=$(MARKET_IMAGE_VERSION) --tag $(IMAGE):$(MARKET_IMAGE_VERSION) --push .
 
 market-pull:
 	docker pull $(IMAGE):$(MARKET_IMAGE_VERSION)

--- a/README.en.md
+++ b/README.en.md
@@ -70,14 +70,16 @@ User code lives separately at `/workspace`. Compose combines a named `dsh-home` 
 
 | Problem | Upstream behavior | Project decision |
 | --- | --- | --- |
-| Node version | Requires Node 22.19+ or 24+ | Pin Node 24 slim |
-| Native dependency | `node-pty` lacks prebuilds for some architectures | Compile in a builder stage; keep compilers out of the runtime image |
+| Node / glibc | Requires Node 22.19+ or 24+; some user binaries require a newer glibc | Pin the official non-slim `node:24-trixie`, Debian 13 with glibc 2.41 |
+| Native dependencies and Agent tools | `node-pty` or third-party plugins may need native builds; the Agent needs common development commands | Install DSH in a separate stage; intentionally retain the buildpack-deps toolchain at runtime and add `jq`, `less`, `ripgrep`, `rsync`, `zip`, and related tools |
 | Web bind | The CLI intentionally rejects `--host 0.0.0.0` | Use a Cordis overlay and publish only to host `127.0.0.1` |
 | Web security | No TLS, authentication, or origin policy; tools can execute code | No Ingress/LoadBalancer; loopback-only Compose; deny Pod ingress by default |
 | HMR | A config watcher needs Node internals after boot | Pass `--expose-internals` only to the DSH process, never through inherited `NODE_OPTIONS` |
 | Directory browser | Starts at `os.homedir()` | Point `HOME` at writable `/workspace` instead of read-only `/home/node` |
 | Child processes | Agents can create shell and PTY subprocesses | Use `tini` for signal forwarding and orphan reaping |
 | Least privilege | The workspace must be writable without exposing the host | UID 1000, read-only root, drop ALL, no-new-privileges, and minimal mounts |
+
+Choosing the non-slim base is an explicit coding-agent trade-off rather than a smallest-image goal. Debian 13 Trixie raises glibc from Bookworm's 2.36 to 2.41, allowing more binaries built on recent systems to run. The official non-slim Node variant is based on `buildpack-deps` and already includes the compiler, `make`, `git`, `curl`, `file`, `unzip`, `wget`, and `xz`; this project explicitly adds `jq`, `less`, `ripgrep`, `rsync`, and `zip`. The trade-off is roughly 330 MB more compressed base-image data than slim. The smoke test asserts Trixie, glibc 2.41, and the complete command contract so a later upgrade cannot silently regress them.
 
 The Web bind is the most important trade-off. Docker bridge publication requires the process to listen beyond the container loopback interface, while Harness deliberately rejects `--host 0.0.0.0` to prevent accidental exposure of an unauthenticated code-execution surface. The container overlay changes only the internal listener. The deployment boundary then restores the intended posture: Compose binds the host side to `127.0.0.1`, and Kubernetes access uses `kubectl port-forward`. Changing this to `-p 3080:3080`, NodePort, LoadBalancer, or a public Ingress breaks the security model.
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,16 @@ flowchart TB
 
 | 难点 | 上游行为 | 本项目决策 |
 | --- | --- | --- |
-| Node 版本 | 要求 Node 22.19+ 或 24+ | 固定 Node 24 slim |
-| 原生依赖 | `node-pty` 在部分架构没有 prebuild | 多阶段构建，builder 带 `node-gyp` 工具链，runtime 不带编译器 |
+| Node / glibc | 要求 Node 22.19+ 或 24+；部分用户二进制需要较新 glibc | 固定官方 `node:24-trixie` 非 slim，Debian 13 / glibc 2.41 |
+| 原生依赖与 Agent 工具 | `node-pty` 或第三方插件可能需要本机构建；Agent 需要常见开发命令 | 多阶段安装 DSH；runtime 有意保留 buildpack-deps 工具链，并补齐 `jq`、`less`、`ripgrep`、`rsync`、`zip` 等命令 |
 | Web 监听 | CLI 主动拒绝 `--host 0.0.0.0` | 使用 Cordis overlay；宿主端口只能绑定 `127.0.0.1` |
 | Web 安全 | 当前无 TLS、认证和 Origin 策略，可触发代码执行 | 不提供 Ingress/LoadBalancer；Compose 回环发布；Helm 默认拒绝 Pod 入站 |
 | HMR | 启动后挂载配置 watcher，需要 Node internals | 仅给 DSH 主进程传 `--expose-internals`，不通过 `NODE_OPTIONS` 传播给 Agent 子进程 |
 | 目录选择器 | 浏览模式以 `os.homedir()` 为首页 | 将 `HOME` 指向可写 `/workspace`，避免只读 `/home/node` 的 EROFS |
 | 信号和子进程 | Agent 会创建 shell/PTY 子进程 | 使用 `tini` 转发信号和回收孤儿进程 |
 | 权限 | 工具需要工作区写入，但不应获得宿主权限 | UID 1000、只读根文件系统、drop ALL、no-new-privileges、最小挂载 |
+
+默认基础镜像选择非 slim 是面向 coding agent 的明确取舍，而不是追求最小体积。Debian 13 Trixie 将 glibc 从 Bookworm 的 2.36 提升到 2.41，能运行更多按新系统构建的二进制；官方 Node 非 slim 变体基于 `buildpack-deps`，自带编译器、`make`、`git`、`curl`、`file`、`unzip`、`wget`、`xz` 等开发工具，本项目再显式安装 `jq`、`less`、`ripgrep`、`rsync` 和 `zip`。代价是基础镜像压缩体积比 slim 大约增加 330 MB；Smoke Test 会同时检查 Trixie、glibc 2.41 和完整命令清单，避免后续升级意外退化。
 
 这里最需要强调的是 Web 监听：Docker bridge 端口转发要求容器进程监听非 loopback 地址，但 Harness 的 CLI 正是为了防止未认证 RCE 被误暴露而禁止 `--host 0.0.0.0`。本项目只在容器内部用官方 patch 机制改监听地址，并把安全责任收回到部署边界：Compose 只发布 `127.0.0.1`，Kubernetes 只建议 `kubectl port-forward`。如果把它改成 `-p 3080:3080`、NodePort、LoadBalancer 或公开 Ingress，就破坏了这个安全模型。
 

--- a/compose.market.yaml
+++ b/compose.market.yaml
@@ -6,4 +6,5 @@ services:
         BASE_IMAGE: runzhliu/deepseek-harness:${DSH_VERSION:-0.1.1-rc.2}
         DSH_MARKET_VERSION: ${DSH_MARKET_VERSION:-1.21.0}
         MARKET_IMAGE_VERSION: ${MARKET_IMAGE_VERSION:-0.1.1-rc.2-market.1}
+        NODE_IMAGE: ${NODE_IMAGE:-node:24-trixie}
     image: runzhliu/deepseek-harness:${MARKET_IMAGE_VERSION:-0.1.1-rc.2-market.1}

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
       context: .
       args:
         DSH_VERSION: ${DSH_VERSION:-0.1.1-rc.2}
+        NODE_IMAGE: ${NODE_IMAGE:-node:24-trixie}
     image: runzhliu/deepseek-harness:${DSH_VERSION:-0.1.1-rc.2}
     ports:
       - "127.0.0.1:${DSH_PORT:-3080}:3080"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -27,6 +27,33 @@ if [[ "${actual_pnpm_version}" != "${expected_pnpm_version}" ]]; then
   exit 1
 fi
 
+actual_node_version="$(docker run --rm --entrypoint node "${image}" --version)"
+if [[ "${actual_node_version}" != v24.* ]]; then
+  echo "expected Node.js 24.x from the upstream image, got ${actual_node_version}" >&2
+  exit 1
+fi
+
+runtime_contract="$(docker run --rm --entrypoint sh "${image}" -ec '
+  . /etc/os-release
+  if [ "${VERSION_CODENAME:-}" != trixie ]; then
+    echo "expected Debian trixie, got ${VERSION_CODENAME:-unknown}" >&2
+    exit 1
+  fi
+  libc_version="$(getconf GNU_LIBC_VERSION)"
+  if [ "${libc_version}" != "glibc 2.41" ]; then
+    echo "expected glibc 2.41, got ${libc_version}" >&2
+    exit 1
+  fi
+  for command_name in bash cc curl file git jq less make python3 rg rsync ssh tar unzip wget xz zip; do
+    if ! command -v "${command_name}" >/dev/null 2>&1; then
+      echo "required coding-agent command is missing: ${command_name}" >&2
+      exit 1
+    fi
+  done
+  printf "debian=%s libc=%s tools=ok\n" "${VERSION_CODENAME}" "${libc_version}"
+')"
+echo "runtime contract passed for ${image} (${runtime_contract})"
+
 if [[ -n "${expected_market_version}" ]]; then
   actual_market_version="$(docker run --rm --entrypoint node "${image}" -p \
     'require("/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/dshmarket/package.json").version')"


### PR DESCRIPTION
## Summary

- move the default and optional-market builders/runtime to the official Node 24 Trixie non-slim base
- retain the coding-agent toolchain and explicitly provide common CLI tools
- enforce Node 24, Debian Trixie, glibc 2.41, and the required command set in image smoke tests
- document the compatibility/size trade-off and keep NODE_IMAGE overridable

## Validation

- make verify
- default image build and full smoke test on linux/arm64
- optional-market image build and full smoke test on linux/arm64

Fixes #18