### PR TITLE
chore: track upstream DSH releases

### DIFF
--- a/.github/workflows/upstream-dsh.yml
+++ b/.github/workflows/upstream-dsh.yml
@@ -1,0 +1,56 @@
+name: Upstream DSH version watch
+
+on:
+  schedule:
+    - cron: "23 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Compare GitHub Release and npm
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Check the pinned DSH version
+        id: upstream
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          ./scripts/check-upstream-dsh.sh 0.1.1-rc.2 >upstream-report.txt 2>&1
+          status="$?"
+          echo "status=${status}" >>"${GITHUB_OUTPUT}"
+          exit "${status}"
+      - name: Show the version report
+        if: always()
+        run: cat upstream-report.txt
+      - name: Open an upgrade issue
+        if: steps.upstream.outputs.status == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="chore: upgrade the pinned DSH release"
+          existing="$(gh issue list --state open --search "${title} in:title" --json number --jq length)"
+          if [[ "${existing}" == "0" ]]; then
+            {
+              echo "The scheduled upstream version check found a newer installable DSH release."
+              echo
+              echo '```text'
+              cat upstream-report.txt
+              echo '```'
+              echo
+              echo "Update every pinned version together and run the full multi-architecture smoke tests before publishing."
+            } >upstream-issue.md
+            gh issue create --title "${title}" --body-file upstream-issue.md
+          fi
+      - name: Fail when an upgrade is available
+        if: steps.upstream.outcome == 'failure'
+        run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project are documented here.
 - Change the default builder and runtime base from `node:24-bookworm-slim` to the official non-slim `node:24-trixie`, raising the runtime from glibc 2.36 to 2.41.
 - Keep the buildpack-deps compiler toolchain available to coding-agent and native-plugin workflows, and add an explicit common CLI contract including `jq`, `less`, `ripgrep`, `rsync`, and `zip`.
 - Extend the image smoke test to reject a non-Trixie base, an unexpected glibc version, or any missing required Agent command on both release architectures.
+- Link the pinned DSH version to its exact upstream GitHub Release and npm artifact in the README and image metadata.
+- Add a daily GitHub Release/npm watcher that opens an upgrade issue only after the newest upstream DSH version is installable from npm.
 - Add an explicitly optional `Dockerfile.market` derived image and Compose overlay that pin the third-party `dshmarket@1.21.0` package.
 - Keep the default Docker target, Compose stack, Helm chart, and DSH Web patch free of the community market.
 - Test the default official-DSH integration separately from the optional market variant, including hardened runtime checks and disabled market-owned restarts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ Before opening a pull request:
 5. Update both `README.md` and `README.en.md` when behavior or commands change.
 6. Keep `plugins/dsh-browser-desktop` publishable on its own: run `make plugin-check`, avoid container-only imports, and document any new companion-service requirement.
 
+Run `make upstream-check` when reviewing an upstream DSH release. A GitHub tag alone is not sufficient for this project: the same version must exist as an installable `@deepseek-ai/dsh` npm artifact before changing `DSH_VERSION`.
+
 The public image and plugin must not contain private provider endpoints, credentials, company-internal skills, or personal workspace mounts. Keep machine-specific Compose additions in the git-ignored `compose.local.yaml`.
 
 Please report upstream Harness defects to the upstream channel described by its contribution guide. Issues specific to the Dockerfile, Compose file, Helm chart, or this documentation belong in this project.

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,10 @@ LABEL org.opencontainers.image.title="DeepSeek Harness Docker (Community)" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.version="${DSH_VERSION}" \
       io.github.runzhliu.deepseek-harness.base-image="${NODE_IMAGE}" \
-      io.github.runzhliu.deepseek-harness.debian-codename="trixie"
+      io.github.runzhliu.deepseek-harness.debian-codename="trixie" \
+      io.github.runzhliu.deepseek-harness.upstream.repository="https://github.com/deepseek-ai/deepseek-harness" \
+      io.github.runzhliu.deepseek-harness.upstream.release="https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v${DSH_VERSION}" \
+      io.github.runzhliu.deepseek-harness.upstream.npm="@deepseek-ai/dsh@${DSH_VERSION}"
 
 # Use Node's official non-slim Trixie variant intentionally: its buildpack-deps
 # base provides the compiler and common development utilities a coding agent or

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DSH_MARKET_VERSION ?= 1.21.0
 MARKET_IMAGE_VERSION ?= $(VERSION)-market.1
 PLATFORMS ?= linux/amd64,linux/arm64
 
-.PHONY: help build multiarch-build push pull market-build market-push market-pull up down logs compose-check helm-check plugin-check verify smoke market-smoke inspect market-inspect
+.PHONY: help build multiarch-build push pull market-build market-push market-pull up down logs compose-check helm-check plugin-check verify upstream-check smoke market-smoke inspect market-inspect
 
 help:
 	@echo "build            Build the local platform image"
@@ -18,6 +18,7 @@ help:
 	@echo "up/down/logs     Manage the Compose service"
 	@echo "verify           Validate Compose and Helm rendering"
 	@echo "plugin-check     Validate and dry-pack the browser plugin"
+	@echo "upstream-check   Compare the pinned DSH version with GitHub and npm"
 	@echo "smoke            Exercise CLI, config, PTY, and Web startup"
 	@echo "inspect          Inspect the remote multi-platform manifest"
 
@@ -66,10 +67,14 @@ plugin-check:
 	node --check scripts/dsh-market-repair-store
 	sh -n scripts/deepseek-harness-entrypoint
 	sh -n scripts/deepseek-harness-market-entrypoint
+	bash -n scripts/check-upstream-dsh.sh
 	bash -n scripts/smoke.sh
 	npm --cache "$${TMPDIR:-/tmp}/dsh-browser-plugin-npm-cache" pack --dry-run --json ./plugins/dsh-browser-desktop >/dev/null
 
 verify: compose-check helm-check plugin-check
+
+upstream-check:
+	./scripts/check-upstream-dsh.sh $(DSH_VERSION)
 
 smoke:
 	./scripts/smoke.sh $(IMAGE):$(VERSION) $(DSH_VERSION) 10.15.1

--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,8 @@
 
 English | [简体中文](README.md)
 
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek_Harness-0.1.1--rc.2-4f46e5)](https://www.npmjs.com/package/@deepseek-ai/dsh)
+[![Upstream DSH](https://img.shields.io/github/v/release/deepseek-ai/deepseek-harness?include_prereleases&sort=semver&label=upstream%20DSH)](https://github.com/deepseek-ai/deepseek-harness/releases)
+[![Container Release](https://img.shields.io/github/v/release/runzhliu/deepseek-harness-docker?include_prereleases&sort=semver&label=container%20release)](https://github.com/runzhliu/deepseek-harness-docker/releases)
 [![Docker Image](https://img.shields.io/badge/docker.io-runzhliu%2Fdeepseek--harness-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/runzhliu/deepseek-harness)
 [![Node.js](https://img.shields.io/badge/Node.js-24-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -11,7 +12,9 @@ A production-minded community container project for the official DeepSeek Harnes
 
 > Current baseline: `@deepseek-ai/dsh@0.1.1-rc.2`. DeepSeek Harness is still a release candidate. Re-run the build and smoke tests before every version upgrade.
 
-`0.1.1-rc.2` maps directly to the official `@deepseek-ai/dsh` artifact in the npm Registry and its matching GitHub Release; it is not a project-defined version. This project packages the installable npm distribution instead of building source, and intentionally does not publish a drifting Docker `latest` tag.
+`0.1.1-rc.2` maps directly to the official [`dsh-v0.1.1-rc.2`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.1-rc.2) Release and [`@deepseek-ai/dsh@0.1.1-rc.2`](https://www.npmjs.com/package/@deepseek-ai/dsh/v/0.1.1-rc.2) in the npm Registry; it is not a project-defined version. This project packages the installable npm distribution instead of building source, and intentionally does not publish a drifting Docker `latest` tag.
+
+> Upstream tracking (2026-08-29): the newest official source pre-release is [`dsh-v0.1.2-alpha.1`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1), but the matching `@deepseek-ai/dsh` package is not yet available from npm. The image therefore remains pinned to the newest installable baseline, `0.1.1-rc.2`. The daily [Upstream DSH version watch](.github/workflows/upstream-dsh.yml) checks both GitHub Releases and npm and opens an upgrade issue once the newest upstream version becomes installable.
 
 📖 Further reading: [DeepSeek Harness GitHub repository deep dive](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-repository-analysis/) · [Docker, Compose, and Helm deployment guide](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-runtime-containerization/) (Chinese)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [English](README.en.md) | 简体中文
 
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek_Harness-0.1.1--rc.2-4f46e5)](https://www.npmjs.com/package/@deepseek-ai/dsh)
+[![Upstream DSH](https://img.shields.io/github/v/release/deepseek-ai/deepseek-harness?include_prereleases&sort=semver&label=upstream%20DSH)](https://github.com/deepseek-ai/deepseek-harness/releases)
+[![Container Release](https://img.shields.io/github/v/release/runzhliu/deepseek-harness-docker?include_prereleases&sort=semver&label=container%20release)](https://github.com/runzhliu/deepseek-harness-docker/releases)
 [![Docker Image](https://img.shields.io/badge/docker.io-runzhliu%2Fdeepseek--harness-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/runzhliu/deepseek-harness)
 [![Node.js](https://img.shields.io/badge/Node.js-24-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -11,7 +12,9 @@
 
 > 当前基线：`@deepseek-ai/dsh@0.1.1-rc.2`。DeepSeek Harness 仍处于 RC 阶段；升级前应重新完成本文的构建和 Smoke Test。
 
-`0.1.1-rc.2` 直接对应官方 npm Registry 与 GitHub Release 的 `@deepseek-ai/dsh` 发行物，并非本项目自定义版本。本项目封装 npm 成品而不从源码构建，因此以可安装的官方发行物为基线，并故意不发布漂移的 Docker `latest` 标签。
+`0.1.1-rc.2` 直接对应官方 [`dsh-v0.1.1-rc.2`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.1-rc.2) Release 与 npm Registry 的 [`@deepseek-ai/dsh@0.1.1-rc.2`](https://www.npmjs.com/package/@deepseek-ai/dsh/v/0.1.1-rc.2)，并非本项目自定义版本。本项目封装 npm 成品而不从源码构建，因此以可安装的官方发行物为基线，并故意不发布漂移的 Docker `latest` 标签。
+
+> 上游版本跟踪（2026-08-29）：官方最新源码预发布版是 [`dsh-v0.1.2-alpha.1`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)，但同版本的 `@deepseek-ai/dsh` 尚未发布到 npm，当前镜像因此继续固定在最新可安装基线 `0.1.1-rc.2`。每日运行的 [Upstream DSH version watch](.github/workflows/upstream-dsh.yml) 会同时检查 GitHub Release 与 npm；最新上游版本可安装后会自动创建升级 Issue。
 
 📖 延伸阅读：[DeepSeek Harness GitHub 仓库深度解析](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-repository-analysis/) · [Docker、Compose 与 Helm 部署实战](https://aik8s.run/ai-k8s/rag-agent/deepseek-harness-runtime-containerization/)
 

--- a/scripts/check-upstream-dsh.sh
+++ b/scripts/check-upstream-dsh.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+pinned_version="${1:-0.1.1-rc.2}"
+upstream_repository="${DSH_UPSTREAM_REPOSITORY:-deepseek-ai/deepseek-harness}"
+npm_package="${DSH_NPM_PACKAGE:-@deepseek-ai/dsh}"
+
+for required_command in gh jq npm; do
+  if ! command -v "${required_command}" >/dev/null 2>&1; then
+    echo "required command is unavailable: ${required_command}" >&2
+    exit 2
+  fi
+done
+
+if ! latest_release_json="$(gh api "repos/${upstream_repository}/releases?per_page=1")"; then
+  echo "could not query GitHub Releases for ${upstream_repository}" >&2
+  exit 2
+fi
+latest_tag="$(jq -r '.[0].tag_name // empty' <<<"${latest_release_json}")"
+latest_release_url="$(jq -r '.[0].html_url // empty' <<<"${latest_release_json}")"
+
+if [[ -z "${latest_tag}" || "${latest_tag}" != dsh-v* ]]; then
+  echo "could not resolve the latest dsh-v* release from ${upstream_repository}" >&2
+  exit 2
+fi
+
+latest_release_version="${latest_tag#dsh-v}"
+if ! latest_npm_version="$(npm view "${npm_package}" version)"; then
+  echo "could not query npm for ${npm_package}" >&2
+  exit 2
+fi
+
+printf 'Pinned DSH:          %s\n' "${pinned_version}"
+printf 'Latest npm:         %s\n' "${latest_npm_version}"
+printf 'Latest GitHub tag:  %s\n' "${latest_tag}"
+printf 'Latest release URL: %s\n' "${latest_release_url}"
+
+if [[ "${latest_npm_version}" != "${pinned_version}" ]]; then
+  echo "A newer npm dist-tag is available: ${npm_package}@${latest_npm_version}" >&2
+  exit 1
+fi
+
+if npm view "${npm_package}@${latest_release_version}" version >/dev/null 2>&1; then
+  if [[ "${latest_release_version}" != "${pinned_version}" ]]; then
+    echo "The latest upstream release is now installable from npm: ${npm_package}@${latest_release_version}" >&2
+    exit 1
+  fi
+  echo "Pinned DSH matches the latest upstream release and npm package."
+else
+  echo "Latest upstream release is not yet available from npm; retaining ${pinned_version}."
+fi


### PR DESCRIPTION
## Summary

- show the latest upstream DSH Release and this repository container Release side by side
- link the pinned DSH version to its exact upstream GitHub Release and npm artifact
- record the upstream repository, Release, and npm package in OCI image labels
- add a daily GitHub/npm watcher that opens an upgrade issue only when the newest upstream version is installable
- document why `dsh-v0.1.2-alpha.1` is not packaged yet: the matching npm artifact has not been published

## Verification

- `make verify`
- `make upstream-check`
- simulated upgrade result exits 1
- simulated GitHub query failure exits 2 and does not open an upgrade issue
- verified both README release badges render the expected tags

## Current version state

- upstream GitHub Release: `dsh-v0.1.2-alpha.1`
- latest npm package: `@deepseek-ai/dsh@0.1.1-rc.2`
- current image baseline: `runzhliu/deepseek-harness:0.1.1-rc.2`
- corresponding repository Release: `dsh-v0.1.1-rc.2`