### PR TITLE
feat: mirror published images to GHCR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Exact official @deepseek-ai/dsh version packaged by the image.
 DSH_VERSION=0.1.1-rc.2
 
+# Published registry repository. Use ghcr.io/runzhliu/deepseek-harness for GHCR.
+DSH_IMAGE_REPOSITORY=runzhliu/deepseek-harness
+
 # Official Node image used by both the default and optional-market builders.
 # Trixie provides glibc 2.41; the non-slim variant includes common build tools.
 NODE_IMAGE=node:24-trixie

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,125 @@
+name: Mirror Docker Hub images to GHCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: DSH image version already published to Docker Hub
+        required: true
+        default: 0.1.1-rc.2
+        type: string
+      include_market:
+        description: Also mirror the version-market.1 image
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ghcr-mirror-${{ github.event_name }}-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+env:
+  SOURCE_IMAGE: docker.io/runzhliu/deepseek-harness
+  TARGET_IMAGE: ghcr.io/runzhliu/deepseek-harness
+
+jobs:
+  mirror:
+    name: Copy multi-platform manifests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Resolve immutable tags
+        id: refs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_INCLUDE_MARKET: ${{ inputs.include_market }}
+        run: |
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            if [[ "${RELEASE_TAG}" != dsh-v* ]]; then
+              echo "release tag must start with dsh-v: ${RELEASE_TAG}" >&2
+              exit 1
+            fi
+            version="${RELEASE_TAG#dsh-v}"
+            include_market=false
+          else
+            version="${INPUT_VERSION}"
+            include_market="${INPUT_INCLUDE_MARKET}"
+          fi
+
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "invalid immutable image version: ${version}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >>"${GITHUB_OUTPUT}"
+          echo "include_market=${include_market}" >>"${GITHUB_OUTPUT}"
+      - uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify Docker Hub sources
+        env:
+          VERSION: ${{ steps.refs.outputs.version }}
+          INCLUDE_MARKET: ${{ steps.refs.outputs.include_market }}
+        run: |
+          docker buildx imagetools inspect "${SOURCE_IMAGE}:${VERSION}"
+          if [[ "${INCLUDE_MARKET}" == "true" ]]; then
+            docker buildx imagetools inspect "${SOURCE_IMAGE}:${VERSION}-market.1"
+          fi
+      - name: Mirror immutable manifests
+        env:
+          VERSION: ${{ steps.refs.outputs.version }}
+          INCLUDE_MARKET: ${{ steps.refs.outputs.include_market }}
+        run: |
+          docker buildx imagetools create \
+            --progress plain \
+            --tag "${TARGET_IMAGE}:${VERSION}" \
+            "${SOURCE_IMAGE}:${VERSION}"
+          if [[ "${INCLUDE_MARKET}" == "true" ]]; then
+            docker buildx imagetools create \
+              --progress plain \
+              --tag "${TARGET_IMAGE}:${VERSION}-market.1" \
+              "${SOURCE_IMAGE}:${VERSION}-market.1"
+          fi
+      - name: Verify mirrored manifest digests
+        env:
+          VERSION: ${{ steps.refs.outputs.version }}
+          INCLUDE_MARKET: ${{ steps.refs.outputs.include_market }}
+        run: |
+          verify_copy() {
+            local source_ref="$1"
+            local target_ref="$2"
+            local report_name="$3"
+
+            docker buildx imagetools inspect --raw "${source_ref}" \
+              | jq -r '.manifests[] | [.digest, .platform.os, .platform.architecture, (.platform.variant // "")] | @tsv' \
+              | sort >"/tmp/${report_name}-source.tsv"
+            docker buildx imagetools inspect --raw "${target_ref}" \
+              | jq -r '.manifests[] | [.digest, .platform.os, .platform.architecture, (.platform.variant // "")] | @tsv' \
+              | sort >"/tmp/${report_name}-target.tsv"
+
+            diff -u "/tmp/${report_name}-source.tsv" "/tmp/${report_name}-target.tsv"
+            grep -q $'\tlinux\tamd64\t' "/tmp/${report_name}-target.tsv"
+            grep -q $'\tlinux\tarm64\t' "/tmp/${report_name}-target.tsv"
+          }
+
+          verify_copy \
+            "${SOURCE_IMAGE}:${VERSION}" \
+            "${TARGET_IMAGE}:${VERSION}" \
+            base
+          if [[ "${INCLUDE_MARKET}" == "true" ]]; then
+            verify_copy \
+              "${SOURCE_IMAGE}:${VERSION}-market.1" \
+              "${TARGET_IMAGE}:${VERSION}-market.1" \
+              market
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here.
 - Extend the image smoke test to reject a non-Trixie base, an unexpected glibc version, or any missing required Agent command on both release architectures.
 - Link the pinned DSH version to its exact upstream GitHub Release and npm artifact in the README and image metadata.
 - Add a daily GitHub Release/npm watcher that opens an upgrade issue only after the newest upstream DSH version is installable from npm.
+- Mirror the published Docker Hub multi-platform manifests to `ghcr.io/runzhliu/deepseek-harness`, with digest verification and no rebuild or `latest` tag.
 - Add an explicitly optional `Dockerfile.market` derived image and Compose overlay that pin the third-party `dshmarket@1.21.0` package.
 - Keep the default Docker target, Compose stack, Helm chart, and DSH Web patch free of the community market.
 - Test the default official-DSH integration separately from the optional market variant, including hardened runtime checks and disabled market-owned restarts.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMAGE ?= runzhliu/deepseek-harness
+GHCR_IMAGE ?= ghcr.io/runzhliu/deepseek-harness
 VERSION ?= 0.1.1-rc.2
 DSH_VERSION ?= $(VERSION)
 NODE_IMAGE ?= node:24-trixie
@@ -6,13 +7,14 @@ DSH_MARKET_VERSION ?= 1.21.0
 MARKET_IMAGE_VERSION ?= $(VERSION)-market.1
 PLATFORMS ?= linux/amd64,linux/arm64
 
-.PHONY: help build multiarch-build push pull market-build market-push market-pull up down logs compose-check helm-check plugin-check verify upstream-check smoke market-smoke inspect market-inspect
+.PHONY: help build multiarch-build push pull ghcr-pull market-build market-push market-pull up down logs compose-check helm-check plugin-check verify upstream-check smoke market-smoke inspect ghcr-inspect market-inspect
 
 help:
 	@echo "build            Build the local platform image"
 	@echo "multiarch-build  Build both release platforms without pushing"
 	@echo "push             Build and push the versioned multi-platform image"
 	@echo "pull             Pull the published image"
+	@echo "ghcr-pull        Pull the GHCR mirror of the published image"
 	@echo "market-build     Build the optional community-market image"
 	@echo "market-push      Build and push its versioned multi-platform image"
 	@echo "up/down/logs     Manage the Compose service"
@@ -33,6 +35,9 @@ push:
 
 pull:
 	docker pull $(IMAGE):$(VERSION)
+
+ghcr-pull:
+	docker pull $(GHCR_IMAGE):$(VERSION)
 
 market-build:
 	docker build --pull --file Dockerfile.market --build-arg BASE_IMAGE=$(IMAGE):$(VERSION) --build-arg NODE_IMAGE=$(NODE_IMAGE) --build-arg DSH_MARKET_VERSION=$(DSH_MARKET_VERSION) --build-arg MARKET_IMAGE_VERSION=$(MARKET_IMAGE_VERSION) --tag $(IMAGE):$(MARKET_IMAGE_VERSION) .
@@ -84,6 +89,9 @@ market-smoke:
 
 inspect:
 	docker buildx imagetools inspect $(IMAGE):$(VERSION)
+
+ghcr-inspect:
+	docker buildx imagetools inspect $(GHCR_IMAGE):$(VERSION)
 
 market-inspect:
 	docker buildx imagetools inspect $(IMAGE):$(MARKET_IMAGE_VERSION)

--- a/README.en.md
+++ b/README.en.md
@@ -5,6 +5,7 @@ English | [简体中文](README.md)
 [![Upstream DSH](https://img.shields.io/github/v/release/deepseek-ai/deepseek-harness?include_prereleases&sort=semver&label=upstream%20DSH)](https://github.com/deepseek-ai/deepseek-harness/releases)
 [![Container Release](https://img.shields.io/github/v/release/runzhliu/deepseek-harness-docker?include_prereleases&sort=semver&label=container%20release)](https://github.com/runzhliu/deepseek-harness-docker/releases)
 [![Docker Image](https://img.shields.io/badge/docker.io-runzhliu%2Fdeepseek--harness-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/runzhliu/deepseek-harness)
+[![GHCR](https://img.shields.io/badge/ghcr.io-runzhliu%2Fdeepseek--harness-2088FF?logo=github&logoColor=white)](https://github.com/users/runzhliu/packages/container/package/deepseek-harness)
 [![Node.js](https://img.shields.io/badge/Node.js-24-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
@@ -125,7 +126,15 @@ docker compose ps
 
 Open <http://127.0.0.1:3080> and configure a model and credentials in Settings. The **Browser** action in the sidebar opens an interactive container Chromium directly inside the Harness Web UI. The named `dsh-home` volume preserves both Harness state and the browser profile across container recreation.
 
-The default image is [`runzhliu/deepseek-harness:0.1.1-rc.2`](https://hub.docker.com/r/runzhliu/deepseek-harness). Compose retains the `build` definition so the image remains reproducible and reviewable; run `docker compose build --pull` before startup when you explicitly want a local build.
+The default image is [`runzhliu/deepseek-harness:0.1.1-rc.2`](https://hub.docker.com/r/runzhliu/deepseek-harness). The same multi-platform artifact is also published to GitHub Container Registry as [`ghcr.io/runzhliu/deepseek-harness:0.1.1-rc.2`](https://github.com/users/runzhliu/packages/container/package/deepseek-harness). Compose retains the `build` definition so the image remains reproducible and reviewable; run `docker compose build --pull` before startup when you explicitly want a local build.
+
+To pull from GHCR without changing the rest of the Compose deployment:
+
+```bash
+DSH_IMAGE_REPOSITORY=ghcr.io/runzhliu/deepseek-harness docker compose pull
+DSH_IMAGE_REPOSITORY=ghcr.io/runzhliu/deepseek-harness \
+  DSH_WORKSPACE=/absolute/path/to/your/project docker compose up -d --no-build
+```
 
 ### Browser inside the Web UI
 
@@ -300,6 +309,8 @@ DSH_VERSION=0.1.1-rc.2 docker compose build --pull
 Maintainers can run `make push` to build and publish the `linux/amd64` and `linux/arm64` manifests under the same versioned tag. The target does not create a `latest` tag.
 
 The optional market variant has a separate `make market-push` target. It publishes only the dual-architecture tag carrying the `-market.1` suffix and never changes the default image.
+
+The [Mirror Docker Hub images to GHCR](.github/workflows/publish-ghcr.yml) workflow creates a carbon copy of an existing Docker Hub manifest in GHCR without rebuilding the image. Publishing a GitHub Release mirrors the base tag; maintainers can also dispatch it with an explicit version and include the `-market.1` variant. It compares every source and target platform-manifest digest after the copy and never creates `latest`.
 
 Do not install an unbounded `latest` tag. Release-candidate behavior changes quickly, and exact versions make bugs reproducible.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Upstream DSH](https://img.shields.io/github/v/release/deepseek-ai/deepseek-harness?include_prereleases&sort=semver&label=upstream%20DSH)](https://github.com/deepseek-ai/deepseek-harness/releases)
 [![Container Release](https://img.shields.io/github/v/release/runzhliu/deepseek-harness-docker?include_prereleases&sort=semver&label=container%20release)](https://github.com/runzhliu/deepseek-harness-docker/releases)
 [![Docker Image](https://img.shields.io/badge/docker.io-runzhliu%2Fdeepseek--harness-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/runzhliu/deepseek-harness)
+[![GHCR](https://img.shields.io/badge/ghcr.io-runzhliu%2Fdeepseek--harness-2088FF?logo=github&logoColor=white)](https://github.com/users/runzhliu/packages/container/package/deepseek-harness)
 [![Node.js](https://img.shields.io/badge/Node.js-24-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
@@ -124,7 +125,15 @@ docker compose ps
 
 浏览器打开 <http://127.0.0.1:3080>，在设置页配置模型和凭据。侧边栏的“浏览器”按钮会在 Harness WebUI 内直接打开可交互的容器 Chromium；配置和浏览器 Profile 写入命名卷 `dsh-home`，重建容器后仍会保留。
 
-默认镜像为 Docker Hub 上的 [`runzhliu/deepseek-harness:0.1.1-rc.2`](https://hub.docker.com/r/runzhliu/deepseek-harness)。Compose 同时保留 `build` 配置，方便审查并从本目录复现镜像；如需本地构建，执行 `docker compose build --pull` 后再启动。
+默认镜像为 Docker Hub 上的 [`runzhliu/deepseek-harness:0.1.1-rc.2`](https://hub.docker.com/r/runzhliu/deepseek-harness)，同一份多架构制品也发布到 GitHub Container Registry：[`ghcr.io/runzhliu/deepseek-harness:0.1.1-rc.2`](https://github.com/users/runzhliu/packages/container/package/deepseek-harness)。Compose 同时保留 `build` 配置，方便审查并从本目录复现镜像；如需本地构建，执行 `docker compose build --pull` 后再启动。
+
+需要从 GHCR 拉取时，设置镜像仓库即可，其他 Compose 配置保持不变：
+
+```bash
+DSH_IMAGE_REPOSITORY=ghcr.io/runzhliu/deepseek-harness docker compose pull
+DSH_IMAGE_REPOSITORY=ghcr.io/runzhliu/deepseek-harness \
+  DSH_WORKSPACE=/absolute/path/to/your/project docker compose up -d --no-build
+```
 
 ### WebUI 内置浏览器
 
@@ -304,6 +313,8 @@ DSH_VERSION=0.1.1-rc.2 docker compose build --pull
 维护者可用 `make push` 构建并推送同一个版本标签下的 `linux/amd64` 与 `linux/arm64` manifest。该命令不会创建 `latest` 标签。
 
 可选市场变体使用独立的 `make market-push`，只发布带 `-market.1` 后缀的双架构标签，不改变默认镜像。
+
+[Mirror Docker Hub images to GHCR](.github/workflows/publish-ghcr.yml) 工作流使用现有 Docker Hub manifest 创建 GHCR 碳拷贝，不重新构建镜像。发布 GitHub Release 时会同步基础标签；维护者也可手动指定版本，并选择同时同步 `-market.1` 变体。同步后会比较源和目标的全部平台 manifest digest，且不会创建 `latest`。
 
 不要默认安装 `latest`。RC 版本正在快速变化，固定版本才能让问题可复现。
 

--- a/compose.market.yaml
+++ b/compose.market.yaml
@@ -3,8 +3,8 @@ services:
     build:
       dockerfile: Dockerfile.market
       args:
-        BASE_IMAGE: runzhliu/deepseek-harness:${DSH_VERSION:-0.1.1-rc.2}
+        BASE_IMAGE: ${DSH_IMAGE_REPOSITORY:-runzhliu/deepseek-harness}:${DSH_VERSION:-0.1.1-rc.2}
         DSH_MARKET_VERSION: ${DSH_MARKET_VERSION:-1.21.0}
         MARKET_IMAGE_VERSION: ${MARKET_IMAGE_VERSION:-0.1.1-rc.2-market.1}
         NODE_IMAGE: ${NODE_IMAGE:-node:24-trixie}
-    image: runzhliu/deepseek-harness:${MARKET_IMAGE_VERSION:-0.1.1-rc.2-market.1}
+    image: ${DSH_IMAGE_REPOSITORY:-runzhliu/deepseek-harness}:${MARKET_IMAGE_VERSION:-0.1.1-rc.2-market.1}

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       args:
         DSH_VERSION: ${DSH_VERSION:-0.1.1-rc.2}
         NODE_IMAGE: ${NODE_IMAGE:-node:24-trixie}
-    image: runzhliu/deepseek-harness:${DSH_VERSION:-0.1.1-rc.2}
+    image: ${DSH_IMAGE_REPOSITORY:-runzhliu/deepseek-harness}:${DSH_VERSION:-0.1.1-rc.2}
     ports:
       - "127.0.0.1:${DSH_PORT:-3080}:3080"
       - "127.0.0.1:${DSH_DESKTOP_PORT:-6080}:6080"


### PR DESCRIPTION
## Summary

- mirror immutable multi-platform Docker Hub manifests to GitHub Container Registry without rebuilding
- verify copied child digests and linux/amd64 + linux/arm64 coverage
- document GHCR usage and make the Compose repository configurable
- keep latest unpublished to avoid a second moving release channel

## Validation

- make verify
- git diff --check
- compose rendering with DSH_IMAGE_REPOSITORY=ghcr.io/runzhliu/deepseek-harness
- Makefile GHCR targets dry-run